### PR TITLE
Fixes Chrome problem where sub name is too high

### DIFF
--- a/Whoaverse/Whoaverse/Content/Site.css
+++ b/Whoaverse/Whoaverse/Content/Site.css
@@ -442,6 +442,7 @@ ul.flat-vert {
     font-variant: small-caps;
     font-size: 1.2em;
     vertical-align: bottom;
+    display: -webkit-inline-box; 
 }
 
     .pagename a {


### PR DESCRIPTION
Adds display: -webkit-inline-box;  to .pagename to fix the chrome problem with the sub name being too high
