### PR TITLE
Increased the number of rows in the css editor of subs to be more comfortable and easy to use.

### DIFF
--- a/Whoaverse/Whoaverse/Views/Subverses/Admin/SubverseSettings.cshtml
+++ b/Whoaverse/Whoaverse/Views/Subverses/Admin/SubverseSettings.cshtml
@@ -45,7 +45,7 @@
                     <div class="form-group">
                         @Html.Label("Custom stylesheet, max 4000 characters", htmlAttributes: new { @class = "control-label col-md-2" })
                         <div class="col-md-10">
-                            @Html.TextAreaFor(model => model.Stylesheet, new { @class = "form-control" })
+                            @Html.TextAreaFor(model => model.Stylesheet, new { @class = "form-control", @rows="20"})
                             @Html.ValidationMessageFor(model => model.Stylesheet, "", new { @class = "text-danger" })
                         </div>
                     </div>


### PR DESCRIPTION
Every time someone tries to edit the CSS of a subverse, he/she has to
expand it in order to see it, this was due to a lack of rows in the
TextArea, but I made a small enough change to make it reasonable sized. 

![image](https://cloud.githubusercontent.com/assets/7976220/3459460/e55335fc-020c-11e4-9ebc-fe83b7c33989.png)

I know it's a tiny update but it's simple and makes a big difference :)
