### PR TITLE
Fix error page alignment, panel heading blue border

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -890,7 +890,7 @@ pre, code {
     box-shadow: none;
 }
 
-    .panel-heading, .panel-default > .panel-heading {
+    .panel-heading, .panel-info > .panel-heading, .panel-default > .panel-heading {
         background: #EEE;
         background: -webkit-linear-gradient( top,#EEE,#E8E8E8 );
         background: -moz-linear-gradient( top,#EEE,#E8E8E8 );
@@ -2062,7 +2062,7 @@ textarea.form-control {
 }
 
 /* ! Register
-================================================================================ */
+-------------------------------------------------------------------------------- */
 
 .modal-dialog {
     width: 400px;
@@ -2185,6 +2185,13 @@ textarea.form-control {
             padding: 15px;
             text-align: center;
         }
+
+/* ! 404 Error
+-------------------------------------------------------------------------------- */
+        
+.content.error-page {
+    margin: 0 10px;
+}
 
 /* ! Responsivity
 ================================================================================ */

--- a/Whoaverse/Whoaverse/Views/Errors/DbNotResponding.cshtml
+++ b/Whoaverse/Whoaverse/Views/Errors/DbNotResponding.cshtml
@@ -141,7 +141,7 @@
     <!-- End Must be logged in Modal -->
 
 
-    <div class="content" role="main">
+    <div class="content error-page" role="main">
 
         <div class="container">
             <div class="panel panel-info">

--- a/Whoaverse/Whoaverse/Views/Errors/Error.cshtml
+++ b/Whoaverse/Whoaverse/Views/Errors/Error.cshtml
@@ -16,7 +16,7 @@
     ViewBag.Title = "Whoops!";
 }
 
-<div class="content" role="main">
+<div class="content error-page" role="main">
 
     <div class="container">
         <div class="panel panel-info">

--- a/Whoaverse/Whoaverse/Views/Errors/Error_404.cshtml
+++ b/Whoaverse/Whoaverse/Views/Errors/Error_404.cshtml
@@ -16,7 +16,7 @@
     ViewBag.Title = "Whoops!";
 }
 
-<div class="content" role="main">
+<div class="content error-page" role="main">
 
     <div class="container">
         <div class="panel panel-info">

--- a/Whoaverse/Whoaverse/Views/Errors/SubverseExists.cshtml
+++ b/Whoaverse/Whoaverse/Views/Errors/SubverseExists.cshtml
@@ -16,7 +16,7 @@
     ViewBag.Title = "Mesosad!";
 }
 
-<div class="content" role="main">
+<div class="content error-page" role="main">
 
     <div class="container">
         <div class="panel panel-info">

--- a/Whoaverse/Whoaverse/Views/Errors/Subversenotfound.cshtml
+++ b/Whoaverse/Whoaverse/Views/Errors/Subversenotfound.cshtml
@@ -16,7 +16,7 @@
     ViewBag.Title = "Whoops!";
 }
 
-<div class="content" role="main">
+<div class="content error-page" role="main">
 
     <div class="container">
         <div class="panel panel-info">


### PR DESCRIPTION
I added a class to the error pages so that they no longer follow just the global `.content` class:

``` html
<div class="content error-page" role="main">
<!-- rest of page -->
</div>
```

---

``` css
.content.error-page {
    margin: 0 10px;
}
```
