### PR TITLE
Whoaverse-Dark: Fix white backgrounds and borders in tables

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -134,6 +134,10 @@ label {
     color: #BBB;
 }
 
+.frontpagemascotsidebar {
+    background: #333;
+}
+
 .gray {
     color: #DCDCDC;
 }


### PR DESCRIPTION
This should fix the white backgrounds and borders appearing on the tables in markdown help.
