### PR TITLE
Changed text submission editing textarea width

### DIFF
--- a/Whoaverse/Whoaverse/Content/Site.css
+++ b/Whoaverse/Whoaverse/Content/Site.css
@@ -5299,11 +5299,15 @@ ul.tabmenu.formtab {
 .usertext-edit {
     margin-top: 5px;
     padding: 0 1px;
-    width: 500px;
+    width: 100%;
+	min-width: 100%;
+	max-width: 100%;
 }
 
     .usertext-edit textarea {
-        width: 500px;
+        width: 100%;
+		min-width: 100%;
+		max-width: 100%;
         height: 100px;
     }
 

--- a/Whoaverse/Whoaverse/Views/Shared/_MessageSubmissionDetails.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_MessageSubmissionDetails.cshtml
@@ -70,7 +70,7 @@
                             </div>
                         </div>
 
-                        <div class="usertext-edit" style="width: 775px; display: none;">
+                        <div class="usertext-edit" style="display: none;">
                             <div>
                                 <textarea aria-invalid="false" class="form-control valid" cols="20" id="MessageContent" name="MessageContent" rows="2" data-rule-required="true" data-msg-required="The text can not be empty.">@Model.MessageContent</textarea>
                                 <span data-valmsg-replace="false" data-valmsg-for="CommentContent" class="field-validation-error"></span>


### PR DESCRIPTION
Changed text submission editing textarea width so that it scales
according to the user's page size, avoiding waste of space on larger
monitors ([Before](http://i.imgur.com/xAF2ymz.png) and
[After](http://i.imgur.com/HqHzwHD.png)) and allowing to scale down for
smaller page sizes ([Before](http://i.imgur.com/EysQ3M9.png) and
[After](http://i.imgur.com/TNqX151.png))
