### PR TITLE
Changed comments and text post width and changed edit text post label functionality

### DIFF
--- a/Whoaverse/Whoaverse/Content/Site.css
+++ b/Whoaverse/Whoaverse/Content/Site.css
@@ -2057,7 +2057,9 @@ body.with-listing-chooser.explore-page #header .pagename {
         }
 
 .md {
-    max-width: 60em;
+    width: 100%;
+    min-width: 100%;
+    max-width: 100%;
     overflow: auto;
     font-size: small;
 }

--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -791,7 +791,9 @@ input, button, select, textarea {
 
 .md {
     font-size: 13px;
-    max-width: 650px;
+    width: 100%;
+    min-width: 100%;
+    max-width: 100%;
     overflow: auto;
 }
 

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -789,7 +789,9 @@ input, button, select, textarea {
 
 .md {
     font-size: 13px;
-    max-width: 650px;
+    width: 100%;
+    min-width: 100%;
+    max-width: 100%;
     overflow: auto;
 }
 

--- a/Whoaverse/Whoaverse/Views/Shared/_MessageSubmissionDetails.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_MessageSubmissionDetails.cshtml
@@ -28,7 +28,8 @@
 <!-- 1 message submission details without comments -->
 <div id="siteTable" class="sitetable linklisting">
     <div id="submissionid-@Model.Id" class="submission odd link self id-@Model.Id" data-fullname="@Model.Id" data-ups="" data-downs="">
-        <p class="parent"></p>
+        <a name="submissionTop"></a>
+		<p class="parent"></p>
         <span class="rank">1</span>
 
         @Html.Partial("_votingIconsSubmission", Model, new ViewDataDictionary { { "CCP", commentContributionPoints } })
@@ -95,7 +96,7 @@
                     if (User.Identity.Name == Model.Name)
                     {
                         <li>
-                            <a class="" href="javascript:void(0)" onclick="return editsubmission(@Model.Id)">edit</a>
+                            <a class="" href="#submissionTop" onclick="return editsubmission(@Model.Id)">edit</a>
                         </li>
                         <li>
                             <form class="toggle del-button " action="#" method="get">


### PR DESCRIPTION
AKA the "Kill all the whitespace!" update?

Changed the message display width so that, like the text submission
editor, scales along with the window size.

This affects:
- text submissions [BEFORE](https://i.imgur.com/liZR8Eb.png) | [AFTER](https://i.imgur.com/YgLFCnD.png)
- text expandos on frontpage [BEFORE](https://i.imgur.com/gt050QP.png) | [AFTER](https://i.imgur.com/hmU7mJh.png)
- text expandos on user profile [BEFORE](https://i.imgur.com/vL6P1Qa.png) | [AFTER](https://i.imgur.com/f1QY50O.png)
- comments [BEFORE](https://i.imgur.com/LuY2p4M.png) | [AFTER](https://i.imgur.com/5aPewLg.png)

Also, added a anchor to the top of the text submission, so that [when a
user clicks the edit label, he is taken to the top of the submission.](https://www.youtube.com/watch?v=K400HwiwdvM)

This is because, currently, when you have a large text submission, if
you click the edit label, due to the edit field having a small height,
the page content will go up, however the user is left down at the bottom
probably looking at comments and not the edit field.
