### PR TITLE
Fix for container content overflowing

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -1297,6 +1297,7 @@ pre, code {
     margin-left: auto;
     margin-right: auto;
     max-width: 1075px;
+    overflow: auto;
     padding: 10px;
 }
 

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -1276,6 +1276,7 @@ pre, code {
     margin-left: auto;
     margin-right: auto;
     max-width: 1075px;
+    overflow: auto;
     padding: 10px;
 }
 


### PR DESCRIPTION
This fixes an issue of content overflowing the new container id, seen here:

![Sidebar escapes the container](http://i.imgur.com/IuvS6ua.png)
