### PR TITLE
Add emphasis to the login area, remove footer backdrop

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -1246,14 +1246,13 @@ pre, code {
 
         #header-account {
             font-size: 11px;
-            line-height: 56px;
             padding: 0;
             position: absolute;
             right: 0;
             top: 0;
         }
 
-            #header-account a {
+            #header-account a {k
                 color: #DDD;
             }
                 #header-account a:hover {
@@ -1264,6 +1263,34 @@ pre, code {
                 color: #222;
                 margin: 0 4px;
             }
+
+            /* logged in */
+            
+            .logged-in {
+                background: #292929;
+                border: 1px solid #222;
+                border-radius: 3px;
+                margin: 14px 0 0;
+                padding: 5px;
+            }
+            
+            /* logged out */
+            
+            .logged-out {
+                background: #292929;
+                border: 1px solid #222;
+                border-radius: 3px;
+                margin: 14px 0 0;
+                padding: 5px;
+            }
+
+                #header-account .logged-out a {
+                    color: #56A8DA;
+                    font-weight: bold;
+                }
+                    #header-account .logged-out a:hover {
+                        text-decoration: underline;
+                    }
 
         #mail {
             display: inline-block;
@@ -1978,11 +2005,9 @@ pre, code {
 -------------------------------------------------------------------------------- */
 
 .footer-container {
-    text-align: center;
-    background: #333;
-    border-top: 1px solid #222;
     clear: both;
     margin-top: 10px;
+    text-align: center;
 }
 
     .footer {

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -1225,7 +1225,6 @@ pre, code {
 
         #header-account {
             font-size: 11px;
-            line-height: 56px;
             padding: 0;
             position: absolute;
             right: 0;
@@ -1243,6 +1242,32 @@ pre, code {
                 color: #BBB;
                 margin: 0 4px;
             }
+
+            /* logged in */
+            
+            .logged-in {
+                background: #F6F6F6;
+                border: 1px solid #DCDCDC;
+                border-radius: 3px;
+                margin: 14px 0 0;
+                padding: 5px;
+            }
+
+            .logged-out {
+                background: #F6F6F6;
+                border: 1px solid #DCDCDC;
+                border-radius: 3px;
+                margin: 14px 0 0;
+                padding: 5px;
+            }
+
+                #header-account .logged-out a {
+                    color: #4AABE7;
+                    font-weight: bold;
+                }
+                    #header-account .logged-out a:hover {
+                        text-decoration: underline;
+                    }
 
         #mail {
             display: inline-block;
@@ -1955,8 +1980,6 @@ pre, code {
 -------------------------------------------------------------------------------- */
 
 .footer-container {
-    background: #FFF;
-    border-top: 1px solid #DCDCDC;
     clear: both;
     margin-top: 10px;
     text-align: center;

--- a/Whoaverse/Whoaverse/Views/Shared/_LoginPartial.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_LoginPartial.cshtml
@@ -22,6 +22,7 @@
     {
         @Html.AntiForgeryToken()
         <div id="header-account">
+            <div class="logged-in">
             <span class="user">@Html.ActionLink(User.Identity.Name, "UserProfile", "Home", routeValues: new { Id = User.Identity.Name, whattodisplay = String.Empty }, htmlAttributes: new { title = "Profile" })&nbsp;(<span class="userkarma" title="submission contribution points">@linkKarma</span>|<span class="userkarma" title="comment contribution points">@commentKarma</span>)</span>
             <span class="separator">|</span>
             <span class="user">@Html.ActionLink("Manage", "Manage", "Account", routeValues: null, htmlAttributes: new { title = "Manage" })</span>
@@ -36,6 +37,7 @@
             }            
             <span class="separator">|</span>
             <a href="javascript:document.getElementById('logoutForm').submit()">Log off</a>
+            </div>
         </div>
     }
 
@@ -45,13 +47,17 @@ else
     if (!Request.Browser.IsMobileDevice)
     {
         <div id="header-account">
+            <div class="logged-out">
             <span class="user">want to join? <a href="#" onclick="mustLogin();" class="login-required">login</a> or <a href="/account/register">register</a> in seconds</span>
+            </div>
         </div>
     }
     else
     {
         <div id="header-account">
+            <div class="logged-out">
             <span class="user" onclick="mustLogin();"><a href="#" class="login-required">login or register</a></span>
+            </div>
         </div>
     }
 }


### PR DESCRIPTION
Here are the changes:
- A shaded box surrounds the login area with 'login' and 'register' in bold, blue print for emphasis and added weight.
- The footer background now blends in with the body background until a way to keep the footer on the bottom is implemented.

Here is the result:

![](http://i.imgur.com/Xi8tPRK.png)

The shaded box was originally added to the area only when users weren't logged in, but I decided to also implement it for logged-in users for consistency. :-)

How does it look?
