### PR TITLE
Disable added emphasis on the login area on mobile view

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -2313,6 +2313,14 @@ textarea.form-control {
         padding: 6px;
     }
 
+        .logged-in, .logged-out {
+            background: none;
+            border: 0;
+            border-radius: 0;
+            margin: 0;
+            padding: 0;
+        }
+
     #header-banner {
         font-size: 13px;
         height: 64px;

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -2288,6 +2288,14 @@ textarea.form-control {
         padding: 6px;
     }
 
+        .logged-in, .logged-out {
+            background: none;
+            border: 0;
+            border-radius: 0;
+            margin: 0;
+            padding: 0;
+        }
+
     #header-banner {
         font-size: 13px;
         height: 64px;


### PR DESCRIPTION
This disables the added shadow box and margins on mobile view, but the 'login' and 'register' should still remain emphasized. :-)
