### PR TITLE
Focus on textarea when replying to comment and added preview to "edit comment" form

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -306,6 +306,8 @@ function reply(parentcommentid, messageid) {
         null,
         function (data) {
             $("#" + parentcommentid).append(data);
+			//Focus the cursor on the comment reply form textarea, to prevent unnecessary use of the tab key
+			$('#commentreplyform-' + parentcommentid).find('#CommentContent').focus();
         }
      );
 

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
@@ -227,8 +227,23 @@
                     <span data-valmsg-replace="false" data-valmsg-for="CommentContent" class="field-validation-error"></span>
                     <div class="usertext-buttons">
                         <input value="Save" class="btn-whoaverse-paging" type="submit">
+						<input type="button" id="previewButton" value="Preview" class="btn-whoaverse-paging" onclick="showMessagePreview(this,$(this.parentElement.parentElement).find('#CommentContent'),$(this.parentElement.parentElement).find('#submission-preview-area'))">
                         <button class="btn-whoaverse-paging" onclick="removeeditform(@commentId)" type="button">Cancel</button>
                     </div>
+					<div class="form-group">
+						<div class="panel panel-default" id="submission-preview-area" style="display: none">
+							<div class="panel-heading">
+								<h4 class="panel-title">Preview</h4>
+							</div>
+							<div class="panel-body">
+								<div class="usertext-body may-blank-within">
+									<div class="md" id="submission-preview-area-container">
+										Loading preview...
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
                 </div>
             </div>
 

--- a/Whoaverse/Whoaverse/Views/Shared/Userprofile/_UserProfileComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Userprofile/_UserProfileComment.cshtml
@@ -115,8 +115,8 @@
                     <li class="first">
                         <a href="/v/@Model.Message.Subverse/comments/@Model.MessageId/@Model.Id" class="bylink" rel="nofollow">permalink</a>
                     </li>
-                    <li>
-                        <a href="#" class="bylink" rel="nofollow">context</a>
+                    <li class="first">
+                        <a href="/v/@Model.Message.Subverse/comments/@Model.MessageId#@Model.Id" class="bylink" rel="nofollow">context</a>
                     </li>
                     <li class="first">
                         <a href="~/v/@Model.Message.Subverse/comments/@Model.MessageId" class="may-blank">full comments (@Model.Message.Comments.Count)</a>


### PR DESCRIPTION
- When clicking to reply to a comment, the cursor should now be focused in the comment reply textarea (as asked on [this thread](https://voat.co/v/ideasforvoat/comments/41156))
- Added preview to the "Edit Comment" form

"Thank you for your attention and have a nice day" - Walter Bishop