### PR TITLE
Fixed edit comment preview not displaying and focus on textarea when editing comment

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -510,7 +510,7 @@ function postPrivateMessageReplyAjax(senderButton, parentprivatemessageid) {
 function edit(parentcommentid, messageid) {
 
     //hide original text comment
-    $("#" + parentcommentid).find('.usertext-body').toggle(1);
+    $("#" + parentcommentid).find('#commentContent-' + messageid).toggle(1);
 
     //show edit form
     $("#" + parentcommentid).find('.usertext-edit').toggle(1);

--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -510,7 +510,7 @@ function postPrivateMessageReplyAjax(senderButton, parentprivatemessageid) {
 function edit(parentcommentid, messageid) {
 
     //hide original text comment
-    $("#" + parentcommentid).find('#commentContent-' + messageid).toggle(1);
+    $('#commentContent-' + parentcommentid).toggle(1);
 
     //show edit form
     $("#" + parentcommentid).find('.usertext-edit').toggle(1);

--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -514,6 +514,9 @@ function edit(parentcommentid, messageid) {
 
     //show edit form
     $("#" + parentcommentid).find('.usertext-edit').toggle(1);
+	
+	//Focus the cursor on the comment reply form textarea, to prevent unnecessary use of the tab key
+	$('#commenteditform-' + parentcommentid).find('#CommentContent').focus();
 
     var form = $('#commenteditform-' + parentcommentid)
             .removeData("validator") /* added by the raw jquery.validate plugin */

--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -515,7 +515,7 @@ function edit(parentcommentid, messageid) {
     //show edit form
     $("#" + parentcommentid).find('.usertext-edit').toggle(1);
 	
-	//Focus the cursor on the comment reply form textarea, to prevent unnecessary use of the tab key
+	//Focus the cursor on the edit comment form textarea, to prevent unnecessary use of the tab key
 	$('#commenteditform-' + parentcommentid).find('#CommentContent').focus();
 
     var form = $('#commenteditform-' + parentcommentid)

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
@@ -205,7 +205,7 @@
 
             @if (commentModel.Name != "deleted")
             {
-                <div class="usertext-body may-blank-within">
+                <div class="usertext-body may-blank-within" id="commentContent-@commentId">
                     <div class="md">
                         @Html.Raw(@Formatting.FormatMessage(@commentModel.CommentContent))
                     </div>
@@ -230,16 +230,14 @@
 						<input type="button" id="previewButton" value="Preview" class="btn-whoaverse-paging" onclick="showMessagePreview(this,$(this.parentElement.parentElement).find('#CommentContent'),$(this.parentElement.parentElement).find('#submission-preview-area'))">
                         <button class="btn-whoaverse-paging" onclick="removeeditform(@commentId)" type="button">Cancel</button>
                     </div>
-					<div class="form-group">
-						<div class="panel panel-default" id="submission-preview-area" style="display: none">
-							<div class="panel-heading">
-								<h4 class="panel-title">Preview</h4>
-							</div>
-							<div class="panel-body">
-								<div class="usertext-body may-blank-within">
-									<div class="md" id="submission-preview-area-container">
-										Loading preview...
-									</div>
+					<div class="panel panel-default" id="submission-preview-area" style="display: none">
+						<div class="panel-heading">
+							<h4 class="panel-title">Preview</h4>
+						</div>
+						<div class="panel-body">
+							<div class="usertext-body may-blank-within">
+								<div class="md" id="submission-preview-area-container">
+									Loading preview...
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
- Fixed edit comment preview not displaying (as mentioned [here](https://github.com/voat/voat/pull/253#issuecomment-71113235))

- When clicking to edit a comment, the cursor should now be focused in the edit comment textarea (similar behaviour as the comment reply)