### PR TITLE
Modal tweaks

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -146,14 +146,35 @@ label {
 }
 
 .alert-firsttimevisitorwelcome {
-    background-color: #292929;
-    border: 1px solid #6F64BA;
-    border-radius: 0;
-    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1);
+    background-color: #303030;
+    border: 1px solid #292929;
+    border-radius: 2px;
+    box-shadow: 0px 2px 0px rgba(0, 0, 0, 0.07);
     color: #DFDFDF;
     font-size: 12px;
     margin: 10px auto;
 }
+
+    .alert-firsttimevisitorwelcome > p {
+        margin: 0 0 10px;
+    }
+
+    a.btn-tour {
+        background: #38434B;
+        background: -webkit-linear-gradient( top,#38434B,#353C44 );
+        background: -moz-linear-gradient( top,#38434B,#353C44 );
+        background: -ms-linear-gradient( top,#38434B,#353C44 );
+        background: -o-linear-gradient( top,#38434B,#353C44 );
+        border: 1px solid #242E39;
+        border-radius: 2px;
+        box-shadow: 0 1px 0 hsla( 0,0%,0%,0.1 );
+        color: #FFF;
+        display: inline-block;
+        font-size: 12px;
+        margin-top: 10px;
+        padding: 3px 7px;
+        text-align: center;
+    }
 
 .set-title {
     border-top: 1px solid;
@@ -2388,6 +2409,10 @@ textarea.form-control {
     line-height: 150%;
     padding: 20px;
 }
+
+    .modal-body > p {
+        margin: 0 0 10px;
+    }
 
 .form-horizontal .form-group {
     margin-left: 0;

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -156,14 +156,35 @@ label {
 }
 
 .alert-firsttimevisitorwelcome {
-    background-color: #FFF;
-    border: 1px solid #94D0F5;
-    border-radius: 0;
-    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1);
-    color: #5A5A5A;
+    background-color: #FDFDFD;
+    border: 1px solid #DCDCDC;
+    border-radius: 2px;
+    box-shadow: 0px 2px 0px rgba(0, 0, 0, 0.07);
+    color: #505050;
     font-size: 12px;
     margin: 10px auto;
 }
+
+    .alert-firsttimevisitorwelcome > p {
+        margin: 0 0 10px;
+    }
+
+    a.btn-tour {
+        background: #4AABE7;
+        background: -webkit-linear-gradient( top,#54B5F1,#4AABE7 );
+        background: -moz-linear-gradient( top,#54B5F1,#4AABE7 );
+        background: -ms-linear-gradient( top,#54B5F1,#4AABE7 );
+        background: -o-linear-gradient( top,#54B5F1,#4AABE7 );
+        border: 1px solid #4C9FD2;
+        border-radius: 2px;
+        box-shadow: 0 1px 0 hsla( 0,0%,0%,0.1 );
+        color: #FFF;
+        display: inline-block;
+        font-size: 12px;
+        margin-top: 10px;
+        padding: 3px 7px;
+        text-align: center;
+    }
 
 .set-title {
     border-top: 1px solid;
@@ -2365,6 +2386,10 @@ textarea.form-control {
     line-height: 150%;
     padding: 20px;
 }
+
+    .modal-body > p {
+        margin: 0 0 10px;
+    }
 
 .form-horizontal .form-group {
     margin-left: 0;

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -2285,7 +2285,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
     border: 1px solid #DFDFDF;
     border-radius: 3px;
     box-shadow: 0 1px 0 hsla( 0,0%,0%,0.1 );
-    color: #444;
+    color: #444 !important;
     display: inline-block;
     font-size: 12px;
     padding: 3px 6px;

--- a/Whoaverse/Whoaverse/Views/Shared/_Layout.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_Layout.cshtml
@@ -214,14 +214,13 @@
                     <h4 class="modal-title" id="notenoughccplabel">Hi! It looks like you are new around here. Welcome to @ConfigurationManager.AppSettings["siteName"]!</h4>
                 </div>
                 <div class="modal-body">
-                    In order to be able to downvote comments or submissions you need to have at least 100 comment contribution points.
-                    <br /><br />
-                    Every time someone upvotes a comment that you wrote, you gain 1 comment contribution point.<br /><br />
-                    Your comment contribution points are shown in the upper right corner like so: (14|2).<br />
+                    <p>In order to be able to downvote comments or submissions you need to have at least 100 comment contribution points.</p>
+                    <p>Every time someone upvotes a comment that you wrote, you gain 1 comment contribution point.</p>
+                    <p>Your comment contribution points are shown in the upper right corner like so: (14|2).<br />
                     The first number (in this case 14), represents submission contribution points (links that you have submitted or discussions that you started).<br />
-                    The second number, in this case 2, represents your comment contribution points.<br /><br />
-                    Tip: a good way to earn more contribution points is to take part in discussions or say hi in /v/introductions.<br /><br />
-                    This requirement was established as a measure to encourage new members to get involved and participate in discussions.<br />
+                    The second number, in this case 2, represents your comment contribution points.</p>
+                    <p>Tip: a good way to earn more contribution points is to take part in discussions or say hi in /v/introductions.</p>
+                    <p>This requirement was established as a measure to encourage new members to get involved and participate in discussions.</p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn-whoaverse-medium" data-dismiss="modal">Ok, got it!</button>
@@ -239,14 +238,14 @@
                     <h4 class="modal-title" id="notenoughccpupvotelabel">Hi! It looks like you are new around here. Welcome to @ConfigurationManager.AppSettings["siteName"]!</h4>
                 </div>
                 <div class="modal-body">
-                    In order to be able to upvote comments or submissions without limitations, you need to have at least 20 comment contribution points.
-                    You are currently limited to 10 upvotes per 24 hours.<br /><br />
-                    Every time someone upvotes a comment that you wrote, you gain 1 comment contribution point.<br /><br />
-                    Your comment contribution points are shown in the upper right corner like so: (14|2).<br />
+                    <p>In order to be able to upvote comments or submissions without limitations, you need to have at least 20 comment contribution points.</p>
+                    <p>You are currently limited to 10 upvotes per 24 hours.
+                    Every time someone upvotes a comment that you wrote, you gain 1 comment contribution point.</p>
+                    <p>Your comment contribution points are shown in the upper right corner like so: (14|2).<br />
                     The first number (in this case 14), represents submission contribution points (links that you have submitted or discussions that you started).<br />
-                    The second number, in this case 2, represents your comment contribution points.<br /><br />
-                    Tip: a good way to earn more contribution points is to take part in discussions or say hi in /v/introductions.<br /><br />
-                    This requirement was established as a measure to encourage new members to get involved and participate in discussions.<br />
+                    The second number, in this case 2, represents your comment contribution points.</p>
+                    <p>Tip: a good way to earn more contribution points is to take part in discussions or say hi in /v/introductions.</p>
+                    <p>This requirement was established as a measure to encourage new members to get involved and participate in discussions.</p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn-whoaverse-medium" data-dismiss="modal">Ok, got it!</button>

--- a/Whoaverse/Whoaverse/Views/Welcome/_FirstTimeVisitorWelcome.cshtml
+++ b/Whoaverse/Whoaverse/Views/Welcome/_FirstTimeVisitorWelcome.cshtml
@@ -13,9 +13,9 @@
 @{
     <div class="alert alert-firsttimevisitorwelcome alert-dismissible" role="alert" style="display: none" id="firsttimevisitorwelcomemessage">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        Hi, it looks like you're new. Welcome to Voat!<br /><br />
-        Voat is a censorship-free community platform based in Switzerland where content is submitted, organized, moderated and voted on (ranked) by the users.<br /><br />
-        Users can earn a percentage of our ad-revenue share for the content they submit.
-        <a href="https://voat.co/about/intro">Would you like a 2-minute-tour?</a>
+        <p>Hi, it looks like you're new. Welcome to Voat!</p>
+        <p>Voat is a censorship-free community platform based in Switzerland where content is submitted, organized, moderated and voted on (ranked) by the users.</p>
+        <p>Users can earn a percentage of our ad-revenue share for the content they submit.</p>
+        <a href="https://voat.co/about/intro" class="btn-tour">Would you like a 2-minute-tour?</a>
     </div>
 }


### PR DESCRIPTION
* The visitor welcome box has been designed to fit with the site while drawing some attention:

    ![](https://cloud.githubusercontent.com/assets/8064810/5889831/a95b1e2e-a3f7-11e4-92c5-5e9e2893a8e7.png)
* Various `<br />` tags in modal popups have been changed to `<p>` tags so their spacing and style rely on CSS rather than pure HTML. `<br />` tags are best used for single-line breaks used in addresses and unformatted lists.
* The white text on the 'Context' button in the inbox has been corrected.

The idea behind the welcome box design was to both (a) not be distracting and (b) be easy to find. Since many browsers skim the left side of the page, a blue button can catch attention and draw the user to either read the welcome box or just click the button itself. However, when the user is either disinterested or does not need to pay attention to it (registered users who enable private browsing, for example), the button and the entire box can be ignored easily.