### PR TITLE
Implement #103 (universal spoiler tag)

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -84,6 +84,25 @@ label {
     border-bottom: 1px solid #272727;
 }
 
+/* Universal spoiler tags */
+.md a[href="#s"] {
+    visibility: hidden;
+    display: inline-block;
+}
+.md a[href="#s"]::after {
+    content: attr(title);
+    background: #773939;
+    color: #773939;
+    border: 1px solid #562828;
+    padding: 2px;
+    visibility: visible;
+}
+.md a[href="#s"]:hover::after,
+.md a[href="#s"]:active::after {
+    color: #DFDFDF;
+    background: #4E2E2E;
+}
+
 /* Alerts */
 
 .alert {
@@ -994,10 +1013,6 @@ a.btn-whoaverse {
 
     .md .single-notification {
         max-width: none;
-    }
-
-    .md a:hover {
-        text-decoration: underline;
     }
 
     .md blockquote {

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -84,6 +84,25 @@ label {
     border-bottom: 1px solid #E9E9E9;
 }
 
+/* Universal spoiler tags */
+.md a[href="#s"] {
+    visibility: hidden;
+    display: inline-block;
+}
+.md a[href="#s"]::after {
+    content: attr(title);
+    background: #E77777;
+    color: #E77777;
+    border: 1px solid #B44F4F;
+    padding: 2px;
+    visibility: visible;
+}
+.md a[href="#s"]:hover::after,
+.md a[href="#s"]:active::after {
+    color: #404040;
+    background: #FFE3E3;
+}
+
 /* Alerts */
 
 .alert {
@@ -988,10 +1007,6 @@ a.btn-whoaverse {
     max-width: 650px;
     overflow: auto;
 }
-
-    .md a:hover {
-        text-decoration: underline;
-    }
 
     .md blockquote {
         background: #F5F5F5;

--- a/Whoaverse/Whoaverse/Views/Shared/Sidebars/_Sidebar.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Sidebars/_Sidebar.cshtml
@@ -113,7 +113,7 @@
             </ul>
         </div>
     </div>
-    <div class="spacer">
+    <div class="spacer spacersection">
         <div class="sidecontentbox ">
             <div class="title">
                 <h1 class="alert-h1">ANNOUNCEMENTS</h1>

--- a/Whoaverse/Whoaverse/Views/Shared/Sidebars/_SidebarFrontpage.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Sidebars/_SidebarFrontpage.cshtml
@@ -62,7 +62,7 @@
         </div>
     </div>
 
-    <div class="spacer">
+    <div class="spacer spacersection">
         <div class="alert-h1">
             Most viewed in the past 24 hours
         </div>
@@ -73,7 +73,7 @@
         </div>
     </div>
 
-    <div class="spacer">
+    <div class="spacer spacersection">
         <div class="alert-h1">
             Voat
         </div>


### PR DESCRIPTION
I did a quick look at the issues, and found #103, which seemed like a quick fix. I present: universal spoiler tags:

![](http://i.imgur.com/fhcn82d.png)

![](http://i.imgur.com/XSy8efr.png)

![](http://i.imgur.com/2fOQf1n.png)

![](http://i.imgur.com/b4vcNu0.png)

The tags are created with the following markdown code:

```
[](#s "spoiler text")
```
