### PR TITLE
Fix sidebar oddity on UserProfile in mobile view

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -2765,11 +2765,17 @@ textarea.form-control {
     #container {
         padding-top: 50px;
     }
+    #container.page-userprofile {
+        padding-top: 10px;
+    }
 
     .side {
         visibility: hidden;
         position: absolute;
         width: 100%;
+    }
+    .page-userprofile .side {
+        display: none;
     }
 
     .side .form-control {

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -2708,11 +2708,17 @@ textarea.form-control {
     #container {
         padding-top: 50px;
     }
+    #container.page-userprofile {
+        padding-top: 10px;
+    }
 
     .side {
         visibility: hidden;
         position: absolute;
         width: 100%;
+    }
+    .page-userprofile .side {
+        display: none;
     }
 
     .side .form-control {

--- a/Whoaverse/Whoaverse/Views/Home/UserProfile.cshtml
+++ b/Whoaverse/Whoaverse/Views/Home/UserProfile.cshtml
@@ -24,7 +24,7 @@
 
 @using Voat.Utils;
 
-<div id="container">
+<div id="container" class="page-userprofile">
 
     @Html.Partial("~/Views/Shared/Sidebars/_SidebarUserInfo.cshtml")
 


### PR DESCRIPTION
Sorry for all the recent small pull requests. I consider bugs/oddities high priority, so I like to get them out of the way first.. :-P

Anyway, this was reported [here](https://voat.co/v/voatdev/comments/49127#61149). The quick solution was to apply a distinctive class for the user profile page so I can hide the sidebar completely in mobile view. Later, I'm going to see what I can do to organize the mobile profile page without completely removing the sidebar.