### PR TITLE
 Fix duplicate requests when loading more comments.  

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -1208,6 +1208,7 @@ function deleteSetExecute(obj, setId) {
 // a function to fetch 1 comment bucket for a submission and append to the bottom of the page
 var loadCommentsRequest;
 function loadMoreComments(obj, submissionId) {
+    if (loadCommentsRequest) { return; }
     $(obj).html("Sit tight...");
 
     // try to see if this request is a subsequent request
@@ -1217,7 +1218,6 @@ function loadMoreComments(obj, submissionId) {
     } else {
         currentPage++;
     }
-    if (loadCommentsRequest) { return; }
     loadCommentsRequest = $.ajax({
         url: "/comments/" + submissionId + "/" + currentPage + "/",
         success: function (data) {

--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -1206,6 +1206,7 @@ function deleteSetExecute(obj, setId) {
 }
 
 // a function to fetch 1 comment bucket for a submission and append to the bottom of the page
+var loadCommentsRequest;
 function loadMoreComments(obj, submissionId) {
     $(obj).html("Sit tight...");
 
@@ -1216,8 +1217,8 @@ function loadMoreComments(obj, submissionId) {
     } else {
         currentPage++;
     }
-
-    $.ajax({
+    if (loadCommentsRequest) { return; }
+    loadCommentsRequest = $.ajax({
         url: "/comments/" + submissionId + "/" + currentPage + "/",
         success: function (data) {
             $("#comments-" + submissionId + "-page").remove();
@@ -1226,6 +1227,9 @@ function loadMoreComments(obj, submissionId) {
         },
         error: function () {
             $(obj).html("That's it. There was nothing else to show. Phew. This was hard.");
+        },
+        complete: function() {
+            loadCommentsRequest = null;
         }
     });
 }


### PR DESCRIPTION
When scrolling quickly, sometimes comments are loaded more than once. This should fix the problem by blocking further requests until the first one returns.