### PR TITLE
Unique contribute button classes, increased link background contrast

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -6,7 +6,7 @@
     ============================================================================ */
 
 .even {
-    background: none repeat scroll 0% 0% #313131;
+    background: #2E2E2E;
 }
 
 .highlightedComment {

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -6,7 +6,7 @@
     ============================================================================ */
 
 .even {
-    background: none repeat scroll 0% 0% #FBFBFB;
+    background: #F8F8F8;
 }
 
 .highlightedComment {

--- a/Whoaverse/Whoaverse/Views/Shared/Navigation/_DomainsMenu.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Navigation/_DomainsMenu.cshtml
@@ -32,6 +32,6 @@
 <ul class="tabmenu ">
     <li class="@classHot"><a href="@selectedSubverse">Hot</a></li>
     <li class="@classNew"><a href="/domains/@selectedDomain/new">New</a></li>
-    <li class="disabled"><a href="/submit?linkpost=true">Share a link</a></li>
-    <li class="disabled"><a href="/submit">Start a discussion</a></li>
+    <li class="disabled share-link"><a href="/submit?linkpost=true">Share a link</a></li>
+    <li class="disabled share-text"><a href="/submit">Start a discussion</a></li>
 </ul>

--- a/Whoaverse/Whoaverse/Views/Shared/Navigation/_TabMenu.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Navigation/_TabMenu.cshtml
@@ -64,8 +64,8 @@
                 <li class="@classHot"><a href="@selectedSubverse" title="Show most popular submissions from default subverses or the ones you are subscribed to.">Hot</a></li>
                 <li class="@classNew"><a href="~/new" title="Show latest submissions from default subverses or the ones you are subscribed to.">New</a></li>
                 <li class="disabled"><a href="~/v/all/new" title="Show latest submissions from all subverses.">Incoming</a></li>
-                <li class="@classLink"><a class="contribute" href="/submit?linkpost=true">Share a link</a></li>
-                <li class="@classDiscussion"><a class="contribute" href="/submit">Start a discussion</a></li>
+                <li class="@classLink"><a class="contribute share-link" href="/submit?linkpost=true">Share a link</a></li>
+                <li class="@classDiscussion"><a class="contribute share-text" href="/submit">Start a discussion</a></li>
             </ul>
         }
     }
@@ -76,8 +76,8 @@
             <li class="@classHot"><a href="@selectedSubverse" title="Show most popular submissions.">Hot</a></li>
             <li class="@classNew"><a href="@selectedSubverse/new" title="Show latest submissions.">New</a></li>
             <li class="@classTop"><a href="@selectedSubverse/top" title="Show all time top ranked submissions.">Top</a></li>
-            <li class="@classLink"><a class="contribute" href="@selectedSubverse/submit?linkpost=true">Share a link</a></li>
-            <li class="@classDiscussion"><a class="contribute" href="@selectedSubverse/submit">Start a discussion</a></li>
+            <li class="@classLink"><a class="contribute share-link" href="@selectedSubverse/submit?linkpost=true">Share a link</a></li>
+            <li class="@classDiscussion"><a class="contribute share-text" href="@selectedSubverse/submit">Start a discussion</a></li>
         </ul>
     }
 }

--- a/Whoaverse/Whoaverse/Views/Shared/Sidebars/_Sidebar.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Sidebars/_Sidebar.cshtml
@@ -31,13 +31,13 @@
     @Html.Partial("_SearchInSubverse", new SearchInSubverseViewModel(), new ViewDataDictionary { { "SelectedSubverse", ViewBag.SelectedSubverse } })
 
     <div class="spacer">
-        <a href="/v/@Model.name/submit?linkpost=true" class="btn-whoaverse btn-block contribute">
+        <a href="/v/@Model.name/submit?linkpost=true" class="btn-whoaverse btn-block contribute share-link">
             Share a link
         </a>
     </div>
 
     <div class="spacer">
-        <a href="/v/@Model.name/submit" class="btn-whoaverse btn-block contribute">
+        <a href="/v/@Model.name/submit" class="btn-whoaverse btn-block contribute share-text">
             Start a discussion
         </a>
     </div>

--- a/Whoaverse/Whoaverse/Views/Shared/Sidebars/_SidebarComments.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Sidebars/_SidebarComments.cshtml
@@ -29,12 +29,12 @@
     @Html.Partial("_SearchInSubverse", new SearchInSubverseViewModel(), new ViewDataDictionary { { "SelectedSubverse", ViewBag.SelectedSubverse } })
     @Html.Partial("~/Views/Shared/Sidebars/_SideBarSubmissionInfo.cshtml")
     <div class="spacer">
-        <a href="/v/@Model.name/submit?linkpost=true" class="btn-whoaverse btn-block contribute">
+        <a href="/v/@Model.name/submit?linkpost=true" class="btn-whoaverse btn-block contribute share-link">
             Share a link
         </a>
     </div>
     <div class="spacer">
-        <a href="/v/@Model.name/submit" class="btn-whoaverse btn-block contribute">
+        <a href="/v/@Model.name/submit" class="btn-whoaverse btn-block contribute share-text">
             Start a discussion
         </a>
     </div>

--- a/Whoaverse/Whoaverse/Views/Shared/Sidebars/_SidebarFrontpage.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Sidebars/_SidebarFrontpage.cshtml
@@ -17,12 +17,12 @@
     @Html.Partial("_SearchMinimal", new SearchViewModel())
 
     <div class="spacer">
-        <a href="/submit?linkpost=true" class="btn-whoaverse btn-block contribute">
+        <a href="/submit?linkpost=true" class="btn-whoaverse btn-block contribute share-link">
             Share a link
         </a>
     </div>
     <div class="spacer">
-        <a href="/submit" class="btn-whoaverse btn-block contribute">
+        <a href="/submit" class="btn-whoaverse btn-block contribute share-text">
             Start a discussion
         </a>
     </div>


### PR DESCRIPTION
As a solution to the issue mentioned [here](https://voat.co/v/CustomizingVoat/comments/60335/101641/102055#102055), the 'Share a link' and 'Start a discussion' contribute buttons/tabs have been given two unique classes: `share-link` and `share-text`.

Additionally, the background contrast between even and odd links has been increased slightly, as promised [many years ago](https://voat.co/v/voatdev/comments/56695/80666/80678#80678).