### PR TITLE
Change OP username to violet in comment threads

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -2425,7 +2425,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
         }
 
     .comment a.submitter {
-        color: #438BB7;
+        color: #6F64BA;
     }
 
     .comment a.moderator {

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -547,7 +547,7 @@ input, button, select, textarea {
         }
 
     .tagline .submitter {
-        color: #308BC4;
+        color: #4AABE7;
     }
 
     .tagline .moderator {
@@ -2382,7 +2382,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
         }
 
     .comment a.submitter {
-        color: #308BC4;
+        color: #8870FF;
     }
 
     .comment a.moderator {


### PR DESCRIPTION
As requested [here](https://voat.co/v/ideasforvoat/comments/72951).

Simply changes the original poster's username in their post's comment threads from dark blue to violet to contrast better from other comments.