### PR TITLE
Fixing about page typo, fixes #409

### DIFF
--- a/Whoaverse/Whoaverse/Views/About/About.cshtml
+++ b/Whoaverse/Whoaverse/Views/About/About.cshtml
@@ -92,7 +92,7 @@
             You can contact us by email through hello@voat.co for all enquiries.
         </p>
         <p>
-            If you have a bug or site issue please submit it to: <a href="https://github.com/voat/voat">https://github.com/voat/voat</a> (preferred) or you can email us at team@whoverse.com.
+            If you have a bug or site issue please submit it to: <a href="https://github.com/voat/voat">https://github.com/voat/voat</a> (preferred) or you can email us at team@whoaverse.com.
         </p>
         <p>
             Those who wish to visit our GitHub repository and dive straight into helping us fix and improve the site are very welcome to do so.


### PR DESCRIPTION
Changing the wrong e-mail on the about page from team@whoverse.com to team@whoaverse.com