### PR TITLE
Visited/unvisited link distinction, comment taglines, comment box resize

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -875,6 +875,7 @@ a.btn-whoaverse {
     -o-transition: border-color 0.1s ease-in-out 0s;
     transition: border-color 0.1s ease-in-out 0s;
     width: 100%;
+    resize: vertical;
 }
 
     .commenttextarea:focus {
@@ -2669,6 +2670,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
 
     .well label.control-label {
         margin-bottom: 5px;
+        resize: vertical;
     }
 
 textarea.form-control {

--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -1080,6 +1080,14 @@ a.btn-whoaverse {
         max-width: none;
     }
 
+    .md a:hover {
+        color: #DC5757 !important;
+    }
+
+    .md a:visited {
+        color: #8A8A8A;
+    }
+
     .md blockquote {
         background: #312D3A;
         border-color: #25212C #25212C #25212C #211E26;

--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -2453,6 +2453,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
     .comment a.author {
         color: #56A8DA;
         font-weight: bold;
+        margin: 3px;
     }
 
         .comment a.author:visited {
@@ -2474,6 +2475,10 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
 
     .comment a.admin {
         color: #E12D39;
+    }
+
+    .comment .tagline .number {
+        font-weight: bold;
     }
 
     .comment .flat-list.buttons li a:hover {

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -1057,6 +1057,10 @@ a.btn-whoaverse {
         text-decoration: underline;
     }
 
+    .md a:visited {
+        color: #9178D0;
+    }
+
     .md blockquote {
         background: #F5F5F5;
         border-color: #E8E8E8 #E8E8E8 #E8E8E8 #DBDBDB;

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -877,6 +877,7 @@ a.btn-whoaverse {
     -o-transition: border-color 0.1s ease-in-out 0s;
     transition: border-color 0.1s ease-in-out 0s;
     width: 100%;
+    resize: vertical;
 }
 
     .commenttextarea:focus {
@@ -2622,6 +2623,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
 
     .well label.control-label {
         margin-bottom: 5px;
+        resize: vertical;
     }
 
 textarea.form-control {

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -2404,6 +2404,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
     .comment a.author {
         color: #4AABE7;
         font-weight: bold;
+        margin: 3px;
     }
 
         .comment a.author:visited {
@@ -2424,6 +2425,10 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
 
     .comment a.admin {
         color: #E12D39;
+    }
+
+    .comment .tagline .number {
+        font-weight: bold;
     }
 
     .comment .flat-list.buttons li a {

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
@@ -149,9 +149,12 @@
                     @Html.Partial("~/Views/Shared/UserDistinctions/_UserDistinction.cshtml", commentModel, new ViewDataDictionary { { "SubverseAnonymized", subverseAnonymized } })
                 }
 
-                <span class="score dislikes">@commentModel.Dislikes points</span>
-                <span class="score unvoted">@commentScore points</span>
-                <span class="score likes">@commentModel.Likes points</span>
+                <span class="score dislikes">
+                    <span class="number">@commentModel.Dislikes</span> points</span>
+                <span class="score unvoted">
+                    <span class="number">@commentScore</span> points</span>
+                <span class="score likes">
+                    <span class="number">@commentModel.Likes</span> points</span>
                 <span class="commentvotesratio">(<span class="post_upvotes">+@commentModel.Likes</span>|<span class="post_downvotes">-@commentModel.Dislikes</span>)</span>
             }
             else


### PR DESCRIPTION
The distinction between visited and unvisited links (by color) has been expanded to include areas given the `md` class, which include almost all user text input. This aims to improve UX in situations of posts and comments consisting of many links.<sup>[[1]](https://voat.co/v/ideasforvoat/comments/111814)</sup>

The ability to horizontally resize some text input forms (primarily comment and post submissions) has been disabled to prevent the form from overflowing into inaccessible areas.<sup>[[2]](https://voat.co/v/voatdev/comments/98297)</sup> Most of these text forms are already defined with a 100% width, so the need to horizontally resize them is virtually nonexistent.

Finally, the taglines on comments have received a subtle adjustment (maximize the image in another tab):

![](http://i.imgur.com/Z7zAuaw.png)

Left and right margins on usernames have increased and the points number has been given more weight.<sup>[[3]](https://voat.co/v/ideasforvoat/comments/111836)</sup> This change slightly highlights and makes it easier to skim and find two high-traffic areas of the comment: the username and the net points. The extra spacing may also improve touch-based UX by somewhat preventing mis-clicks between the expandy-button and the username.