### PR TITLE
Convert DeleteComment method to utilize Dapper

### DIFF
--- a/Whoaverse/Whoaverse/Voat.csproj
+++ b/Whoaverse/Whoaverse/Voat.csproj
@@ -46,6 +46,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
+    <Reference Include="Dapper">
+      <HintPath>..\packages\Dapper.1.42\lib\net45\Dapper.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>
@@ -148,6 +152,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/Whoaverse/Whoaverse/packages.config
+++ b/Whoaverse/Whoaverse/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
   <package id="bootstrap" version="3.3.4" targetFramework="net45" />
+  <package id="Dapper" version="1.42" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="ImageLibrary" version="2.0.5" targetFramework="net45" />


### PR DESCRIPTION
This pull request adds Dapper as a reference and converts the CommentController.DeleteComment method to utilize Dapper instead of Entity Framework.

This is one of more potential Dapper related changes to address #465.

I'd like to convert the Comments and BucketOfComments as-well, which _should_ significantly improve performance around comments.