### PR TITLE
Don't use HTTP_X_FORWARDED_FOR for determining the UserIpAddress

### DIFF
--- a/Whoaverse/Whoaverse/Controllers/CommentController.cs
+++ b/Whoaverse/Whoaverse/Controllers/CommentController.cs
@@ -148,11 +148,7 @@ namespace Voat.Controllers
             // experimental: register a new session for this subverse
             string clientIpAddress = String.Empty;
 
-            if (Request.ServerVariables["HTTP_X_FORWARDED_FOR"] != null)
-            {
-                clientIpAddress = Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-            }
-            else if (Request.UserHostAddress.Length != 0)
+            if (Request.UserHostAddress.Length != 0)
             {
                 clientIpAddress = Request.UserHostAddress;
             }

--- a/Whoaverse/Whoaverse/Controllers/SubversesController.cs
+++ b/Whoaverse/Whoaverse/Controllers/SubversesController.cs
@@ -364,11 +364,7 @@ namespace Voat.Controllers
 
                 // register a new session for this subverse
                 string clientIpAddress = String.Empty;
-                if (Request.ServerVariables["HTTP_X_FORWARDED_FOR"] != null)
-                {
-                    clientIpAddress = Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-                }
-                else if (Request.UserHostAddress.Length != 0)
+                if (Request.UserHostAddress.Length != 0)
                 {
                     clientIpAddress = Request.UserHostAddress;
                 }
@@ -481,11 +477,7 @@ namespace Voat.Controllers
 
                 // register a new session for this subverse
                 string clientIpAddress = String.Empty;
-                if (Request.ServerVariables["HTTP_X_FORWARDED_FOR"] != null)
-                {
-                    clientIpAddress = Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-                }
-                else if (Request.UserHostAddress.Length != 0)
+                if (Request.UserHostAddress.Length != 0)
                 {
                     clientIpAddress = Request.UserHostAddress;
                 }

--- a/Whoaverse/Whoaverse/Utils/AntispamUtility.cs
+++ b/Whoaverse/Whoaverse/Utils/AntispamUtility.cs
@@ -129,7 +129,7 @@ namespace Voat.Utils
             var cache = filterContext.HttpContext.Cache;
 
             // Grab the IP Address from the originating Request (very simple implementation for example purposes)
-            var originationInfo = request.ServerVariables["HTTP_X_FORWARDED_FOR"] ?? request.UserHostAddress;
+            var originationInfo = request.UserHostAddress;
 
             // Append the User Agent
             originationInfo += request.UserAgent;

--- a/Whoaverse/Whoaverse/Utils/User.cs
+++ b/Whoaverse/Whoaverse/Utils/User.cs
@@ -844,11 +844,7 @@ namespace Voat.Utils
         public static string UserIpAddress(HttpRequestBase request)
         {
             string clientIpAddress = String.Empty;
-            if (request.ServerVariables["HTTP_X_FORWARDED_FOR"] != null)
-            {
-                clientIpAddress = request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-            }
-            else if (request.UserHostAddress.Length != 0)
+            if (request.UserHostAddress.Length != 0)
             {
                 clientIpAddress = request.UserHostAddress;
             }


### PR DESCRIPTION
HTTP_X_FORWARDED_FOR can be spoofed easily, so we shouldn't use
it for the UserIpAddress

We have to think of another method for recognizing people who are behind a proxy because if we use the value of HTTP_X_FORWARDED_FOR for calculating the IP hash, it is really easy to vote on the same post with different alt-accounts.