### PR TITLE
Fix subreddit linking with underscores

### DIFF
--- a/Whoaverse/Whoaverse/Utils/Components/ContentFilters.cs
+++ b/Whoaverse/Whoaverse/Utils/Components/ContentFilters.cs
@@ -124,7 +124,7 @@ namespace Voat.Utils.Components {
 
         }
         protected override string ProcessContent(string content, object context) {
-            MatchProcessingReplacer replacer = new MatchProcessingReplacer(@"(?<=\s{1,}|^)((/r/)(?'sub'[a-zA-Z0-9]+))",
+            MatchProcessingReplacer replacer = new MatchProcessingReplacer(@"(?<=\s{1,}|^)((/r/)(?'sub'[a-zA-Z0-9_]+))",
                 delegate(Match m, object state) {
                     return String.Format("[{0}](http://np.reddit.com{0})", m.Value);
                 }


### PR DESCRIPTION
Posting a comment with /r/something_with_underscores on Voat currently would link to /r/something. I changed the regex to match underscores as well.
