### PR TITLE
Bring login/register links to front of tab order

### DIFF
--- a/Whoaverse/Whoaverse/Views/Shared/_LoginPartial.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_LoginPartial.cshtml
@@ -62,7 +62,7 @@ else
     {
         <div id="header-account">
             <div class="logged-out">
-                <span class="user">want to join? <a href="#" onclick="mustLogin();" class="login-required">login</a> or <a href="/account/register">register</a> in seconds</span>
+                <span class="user">want to join? <a href="#" onclick="mustLogin();" class="login-required" tabindex="1">login</a> or <a href="/account/register" tabindex="1">register</a> in seconds</span>
             </div>
         </div>
     }
@@ -70,7 +70,7 @@ else
     {
         <div id="header-account">
             <div class="logged-out">
-                <span class="user" onclick="mustLogin();"><a href="#" class="login-required">login or register</a></span>
+                <span class="user" onclick="mustLogin();"><a href="#" class="login-required" tabindex="1">login or register</a></span>
             </div>
         </div>
     }


### PR DESCRIPTION
Handicapped and keyboard-centric users shouldn't have to tab past dozens of subverse links to reach the all-important login link.

The "most viewed" links also have tabindex="1" set, but they appear later in the DOM tree so the login and register links will be reached first.

-roboticon