### PR TITLE
Prevent errors/XSS attacks when searching with special characters

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -34,7 +34,7 @@
   <system.web>
     <authentication mode="None" />
     <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" requestValidationMode="2.0" />
   </system.web>
   <system.webServer>
     <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">

--- a/Whoaverse/Whoaverse/Controllers/SearchController.cs
+++ b/Whoaverse/Whoaverse/Controllers/SearchController.cs
@@ -25,6 +25,7 @@ namespace Voat.Controllers
         private readonly whoaverseEntities _db = new whoaverseEntities();
 
         [PreventSpam]
+        [ValidateInput(false)]
         [OutputCache(Duration = 600, VaryByParam = "*")]
         public ActionResult SearchResults(int? page, string q, string l, string sub)
         {

--- a/Whoaverse/Whoaverse/Views/Search/FindSubverseSearchResult.cshtml
+++ b/Whoaverse/Whoaverse/Views/Search/FindSubverseSearchResult.cshtml
@@ -18,12 +18,12 @@
     ViewBag.Title = "subverses";
     string searchTerm = "";
 
-    if (!String.IsNullOrEmpty(Request.QueryString["q"]))
+    if (!String.IsNullOrEmpty(Request.Unvalidated.QueryString["q"]))
     {
-        searchTerm = Request.QueryString["q"].ToString(CultureInfo.InvariantCulture);
+        searchTerm = Request.Unvalidated.QueryString["q"].ToString(CultureInfo.InvariantCulture);
     }
 
-    bool includeDescriptions = Request.QueryString["d"].AsBool();
+    bool includeDescriptions = Request.Unvalidated.QueryString["d"].AsBool();
 }
 
 <style type="text/css">

--- a/Whoaverse/Whoaverse/Views/Search/Index.cshtml
+++ b/Whoaverse/Whoaverse/Views/Search/Index.cshtml
@@ -19,14 +19,14 @@
     string searchTerm = "";
     string selectedSubverse = "";
 
-    if (!String.IsNullOrEmpty(Request.QueryString["q"]))
+    if (!String.IsNullOrEmpty(Request.Unvalidated.QueryString["q"]))
     {
-        searchTerm = Request.QueryString["q"].ToString(CultureInfo.InvariantCulture);
+        searchTerm = Request.Unvalidated.QueryString["q"].ToString(CultureInfo.InvariantCulture);
     }
 
     if (!String.IsNullOrEmpty(Request.QueryString["sub"]))
     {
-        selectedSubverse = Request.QueryString["sub"].ToString(CultureInfo.InvariantCulture);
+        selectedSubverse = Request.Unvalidated.QueryString["sub"].ToString(CultureInfo.InvariantCulture);
     }
 
     bool limitSearchToSubverse = Request.QueryString["l"].AsBool();


### PR DESCRIPTION
Not sure if reverting the requestValidationMode to 2.0 is exactly what you want but through searching StackOverflow I believe there's very little harm to it. 

I believe that most of the site has issues with validation throwing "A potentially dangerous Request.QueryString value was detected from the client". So we'll probably need to add something similar to a few other controllers/views. 