### PR TITLE
Change displayed score to net likes

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -270,6 +270,7 @@ function voteUpSubmission(submissionid) {
         //increment score likes counter        
         scoreLikes++;
         submission.find('.score.likes').html(scoreLikes);
+        submission.find('.score.unvoted').html(scoreLikes);
     } else if (submission.children(".midcol").is(".likes")) {
         //REMOVE LIKE IF LIKED
         submission.children(".midcol").toggleClass("unvoted", true); //add class unvoted
@@ -295,6 +296,7 @@ function voteUpSubmission(submissionid) {
         scoreLikes++;
         submission.find('.score.dislikes').html(scoreDislikes);
         submission.find('.score.likes').html(scoreLikes);
+        submission.find('.score.unvoted').html(scoreLikes);
     }
 
 }

--- a/Whoaverse/Whoaverse/Views/Shared/_VotingIconsSubmission.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_VotingIconsSubmission.cshtml
@@ -64,9 +64,9 @@
                 <div class="@votingStatusClassUpArrow login-required" onclick="voteUpSubmission(@Model.Id);" role="button" aria-label="upvote" tabindex="0"></div>
             }
 
-            <div class="score dislikes">@Model.Dislikes</div>
+            <div class="score dislikes">@score</div>
             <div class="score unvoted">@score</div>
-            <div class="score likes">@Model.Likes</div>
+            <div class="score likes">@score</div>
 
             @if (commentContributionPoints < 100)
             {
@@ -89,9 +89,9 @@
     {
         <div class="midcol unvoted">
             <div class="arrow-upvote login-required" onclick="mustLogin();" role="button" aria-label="upvote" tabindex="0" id="upvotebutton-@Model.Id"></div>
-            <div class="score dislikes">@Model.Dislikes</div>
+            <div class="score dislikes">@score</div>
             <div class="score unvoted">@score</div>
-            <div class="score likes">@Model.Likes</div>
+            <div class="score likes">@score</div>
             <div class="arrow-downvote login-required" onclick="mustLogin();" role="button" aria-label="downvote" tabindex="0"></div>
         </div>
 


### PR DESCRIPTION
Suggested change. When a submission is currently voted on, its previous score is updated to either its gross likes if liked or gross dislikes if disliked. This is a confusing and unnecessary feature, as a submission that has a net score of 250 (say, +250/-0) will display a score of 1 if disliked rather than 249. Similarly, a controversial submission with a net score of 5 (+50/-45) will read 51 once liked instead of 6.