### PR TITLE
Ignore Whoaverse/.vs directory created by Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+Whoaverse/.vs/
 
 # Roslyn cache directories
 *.ide


### PR DESCRIPTION
Visual Studio 2015 RC generates IIS config to that directory. It clearly can
be ignored.