### PR TITLE
Default theme for corrupted theme selection state to light

### DIFF
--- a/Whoaverse/Whoaverse/Views/Shared/_Layout.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_Layout.cshtml
@@ -83,16 +83,13 @@
     <meta property="og:site_name" content="@ConfigurationManager.AppSettings["siteName"]" />
     <meta property="og:description" content="@ViewBag.Description" />
 
-    @if (theme != null)
+    @if (theme == null || theme == "light")
     {
-        if (theme == "light")
-        {
-            @Styles.Render("~/Content/Light")
-        }
-        else
-        {
-            @Styles.Render("~/Content/Dark")
-        }
+        @Styles.Render("~/Content/Light")
+    }
+    else
+    {
+        @Styles.Render("~/Content/Dark")
     }
 
     <link rel=StyleSheet href="~/Content/ui-themes/autocomplete/autocompletebundle.min.css" type="text/css">


### PR DESCRIPTION
The default theme is light, so the default theme if the selection state is missing should be light, not _no_  theme.