### PR TITLE
add link to user's sets in top menu bar

### DIFF
--- a/Whoaverse/Whoaverse/Controllers/RSSController.cs
+++ b/Whoaverse/Whoaverse/Controllers/RSSController.cs
@@ -90,7 +90,7 @@ namespace Voat.Controllers
                     submission.Title,
                     submission.MessageContent + "</br>" + "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments",
                     commentsUrl,
-                    submission.Id.ToString(CultureInfo.InvariantCulture),
+                    "Item ID",
                     submission.Date);
                     feedItems.Add(item);
                 }
@@ -116,7 +116,7 @@ namespace Voat.Controllers
                                                 "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments</a>" +
                                                 " | <a href='" + linkUrl + "'>link</a>",
                                                 commentsUrl,
-                                                submission.Id.ToString(CultureInfo.InvariantCulture),
+                                                "Item ID",
                                                 submission.Date);
 
                         feedItems.Add(item);
@@ -127,7 +127,7 @@ namespace Voat.Controllers
                                                 submission.Linkdescription,
                                                 "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments",
                                                 commentsUrl,
-                                                submission.Id.ToString(CultureInfo.InvariantCulture),
+                                                "Item ID",
                                                 submission.Date);
                         feedItems.Add(item);
                     }

--- a/Whoaverse/Whoaverse/Controllers/RSSController.cs
+++ b/Whoaverse/Whoaverse/Controllers/RSSController.cs
@@ -90,7 +90,7 @@ namespace Voat.Controllers
                     submission.Title,
                     submission.MessageContent + "</br>" + "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments",
                     commentsUrl,
-                    "Item ID",
+                    submission.Id.ToString(CultureInfo.InvariantCulture),
                     submission.Date);
                     feedItems.Add(item);
                 }
@@ -116,7 +116,7 @@ namespace Voat.Controllers
                                                 "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments</a>" +
                                                 " | <a href='" + linkUrl + "'>link</a>",
                                                 commentsUrl,
-                                                "Item ID",
+                                                submission.Id.ToString(CultureInfo.InvariantCulture),
                                                 submission.Date);
 
                         feedItems.Add(item);
@@ -127,7 +127,7 @@ namespace Voat.Controllers
                                                 submission.Linkdescription,
                                                 "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments",
                                                 commentsUrl,
-                                                "Item ID",
+                                                submission.Id.ToString(CultureInfo.InvariantCulture),
                                                 submission.Date);
                         feedItems.Add(item);
                     }

--- a/Whoaverse/Whoaverse/Views/Shared/_ListOfSubscribedToSubverses.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_ListOfSubscribedToSubverses.cshtml
@@ -21,7 +21,7 @@
     if (routeDataObject != null)
     {
         showingSubverse = ViewContext.RouteData.Values["activeSubverse"].ToString();
-        
+
         if (showingSubverse == "/")
         {
             selectedFrontpageClass = "selected";
@@ -39,6 +39,12 @@
         <div class="sr-list">
             <ul class="whoaSubscriptionMenu flat-list sr-bar hover">
                 @Html.Partial("_SubscriptionsHoverMenu")
+            </ul>
+            <ul class="flat-list sr-bar hover">
+                <li class="setsmenu">
+                    <span class="separator">-</span>
+                    <a href="/mysets">my sets</a>
+                </li>
             </ul>
             <ul class="flat-list sr-bar hover">
                 <li class="@selectedFrontpageClass">


### PR DESCRIPTION
The link is in the default top menu bar, but missing when “Replace top
menu bar with my subscriptions” is enabled in account options