### PR TITLE
use submission ID as feed item GUID

### DIFF
--- a/Whoaverse/Whoaverse/Controllers/RSSController.cs
+++ b/Whoaverse/Whoaverse/Controllers/RSSController.cs
@@ -90,7 +90,7 @@ namespace Voat.Controllers
                     submission.Title,
                     submission.MessageContent + "</br>" + "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments",
                     commentsUrl,
-                    "Item ID",
+                    submission.Id.ToString(CultureInfo.InvariantCulture),
                     submission.Date);
                     feedItems.Add(item);
                 }
@@ -116,7 +116,7 @@ namespace Voat.Controllers
                                                 "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments</a>" +
                                                 " | <a href='" + linkUrl + "'>link</a>",
                                                 commentsUrl,
-                                                "Item ID",
+                                                submission.Id.ToString(CultureInfo.InvariantCulture),
                                                 submission.Date);
 
                         feedItems.Add(item);
@@ -127,7 +127,7 @@ namespace Voat.Controllers
                                                 submission.Linkdescription,
                                                 "Submitted by " + "<a href='u/" + authorName + "'>" + authorName + "</a> to <a href='" + subverseUrl + "'>" + submission.Subverse + "</a> | <a href='" + commentsUrl + "'>" + submission.Comments.Count() + " comments",
                                                 commentsUrl,
-                                                "Item ID",
+                                                submission.Id.ToString(CultureInfo.InvariantCulture),
                                                 submission.Date);
                         feedItems.Add(item);
                     }


### PR DESCRIPTION
GUIDs should be unique strings in RSS 2.0

This deals with #441, in terms of some feed readers only showing a single item.