### PR TITLE
Fixes overly-long one-word titles not wrapping

### DIFF
--- a/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse-Dark.css
@@ -2099,6 +2099,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
     margin: 0;
     overflow: hidden;
     padding: 0 8px 0 0;
+    word-wrap: break-word;
 }
 
 /* Flairs */

--- a/Whoaverse/Whoaverse/Content/Whoaverse.css
+++ b/Whoaverse/Whoaverse/Content/Whoaverse.css
@@ -2050,6 +2050,7 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
     margin: 0;
     overflow: hidden;
     padding: 0 8px 0 0;
+    word-wrap: break-word;
 }
 
 /* Flairs */


### PR DESCRIPTION
Fixes the issue presented [here](https://voat.co/v/test/comments/164315).<sup>[[archive]](http://web.archive.org/web/20150624220356/https://voat.co/v/test/comments/164315)</sup>

Titles on links and self-posts will now break overly-long one-word titles into a new line if necessary. In all other cases, wrapping behavior should remain normal.