### PR TITLE
Fixed missing && from random() in commit b6d8491

### DIFF
--- a/Whoaverse/Whoaverse/Controllers/SubversesController.cs
+++ b/Whoaverse/Whoaverse/Controllers/SubversesController.cs
@@ -689,7 +689,7 @@ namespace Voat.Controllers
                 {
                     subverse = from subverses in _db.Subverses
                               .Where(s => s.subscribers > 10 && !s.name.Equals("all", StringComparison.OrdinalIgnoreCase) && s.last_submission_received != null
-                                     && !(from ubs in _db.UserBlockedSubverses where ubs.SubverseName.Equals(s.name) select ubs.Username).Contains(User.Identity.Name) !s.admin_disabled.Value)
+                                     && !(from ubs in _db.UserBlockedSubverses where ubs.SubverseName.Equals(s.name) select ubs.Username).Contains(User.Identity.Name) && !s.admin_disabled.Value)
                                select subverses;
                 }
                 else


### PR DESCRIPTION
Somehow dropped an && from the random query. This fixes that issue.