### PR TITLE
Update Submissions.cs to Fix Issue #550

### DIFF
--- a/Whoaverse/Whoaverse/Utils/Submissions.cs
+++ b/Whoaverse/Whoaverse/Utils/Submissions.cs
@@ -21,7 +21,6 @@ namespace Voat.Utils
 {
     public static class Submissions
     {
-        private const double Tolerance = 0.01;
 
         // calculate submission age in days, hours or minutes for use in views
         public static string CalcSubmissionAge(DateTime inPostingDateTime)
@@ -56,7 +55,7 @@ namespace Voat.Utils
                 //days 
                 result = String.Format("{0} day{1}", (int)span.TotalDays, IsPlural((int)span.TotalDays));
             }
-            else if (span.TotalHours > 1 || Math.Abs(span.TotalHours - 1) < Tolerance)
+            else if (span.TotalMinutes >= 60)
             {
                 //hours
                 result = String.Format("{0} hour{1}", (int)span.TotalHours, IsPlural((int)span.TotalHours));


### PR DESCRIPTION
This should fix Issue #550 as detailed at https://github.com/voat/voat/issues/550 . I'm not sure why a tolerance was set for how close the submission time for a post is to one hour. This was causing posts to show "submitted 0 hours ago" when they were exactly 60 minutes old.