### PR TITLE
Add stmp dispose and add the host and port as const params

### DIFF
--- a/Whoaverse/Whoaverse/Utils/EmailUtility.cs
+++ b/Whoaverse/Whoaverse/Utils/EmailUtility.cs
@@ -19,15 +19,19 @@ namespace Voat.Utils
 {
     public class EmailUtility
     {
+        private const string Host = "voat.co";
+        private const int Port = 25;
+        
         // handle email sending
         public static bool SendEmail(MailMessage message)
         {
             try
             {
-                var smtp = new SmtpClient {Host = "voat.co", Port = 25};
+                var smtp = new SmtpClient(Host, Port);
                 message.IsBodyHtml = false;
                 smtp.Send(message);
                 message.Dispose();
+                smtp.Dispose();
                 return true;
             }
             catch (Exception)


### PR DESCRIPTION
Use STMP dispose - https://msdn.microsoft.com/en-us/library/ee706941(v=vs.110).aspx
Always call Dispose before you release your last reference to the SmtpClient. Otherwise, the resources it is using will not be freed so the garbage collector can reclaim the memory.

Moved SmtpClient params to class constants.

Used constructor instead of object initializer.