### PR TITLE
Fix behavior of multiple clicks on subscribe/unsubscribe button

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -951,8 +951,8 @@ $.fn.exists = function () {
 
 // subscribe to subverse
 function subscribe(obj, subverseName) {
-    $(obj).attr("onclick", "unsubscribe(this)");
-    $(obj).html("unsubscribe");
+    $(obj).attr("onclick", "unsubscribe(this, "+JSON.stringify(subverseName)+")");
+    $(obj).toggleClass("btn-sub btn-unsub").html("unsubscribe");
 
     // call the subverse subscribe API
     $.ajax({
@@ -971,8 +971,8 @@ function subscribe(obj, subverseName) {
 
 // unsubscribe from subverse
 function unsubscribe(obj, subverseName) {
-    $(obj).attr("onclick", "subscribe(this)");
-    $(obj).html("subscribe");
+    $(obj).attr("onclick", "subscribe(this, "+JSON.stringify(subverseName)+")");
+    $(obj).toggleClass("btn-sub btn-unsub").html("subscribe");
 
     // call the subverse unsubscribe API
     $.ajax({


### PR DESCRIPTION
Fixes #568

1. `subscribe` and `unsubscribe` functions both require two arguments,
   otherwise the second click on the subscribe toggle button will
   generate a POST request to `/unsubscribe/undefined` on the second
   click.

2. Set the class to the correct `btn-unsub` or `btn-sub` for the state
   of the button.

(You'll have to excuse me, I can't really test this code other than
running it through jshint, but the change is so minor, I don't think it
will cause any errors)