### PR TITLE
duplicate subverse search results fix

### DIFF
--- a/Voat/Voat.UI/Controllers/SearchController.cs
+++ b/Voat/Voat.UI/Controllers/SearchController.cs
@@ -167,7 +167,7 @@ namespace Voat.Controllers
                     .Where(s => s.description.ToLower().Contains(q))
                     .OrderByDescending(s => s.subscribers);
 
-                results = subversesByName.Concat(subversesByDescription).OrderByDescending(s=>s.subscribers);
+                results = subversesByName.Union(subversesByDescription).OrderByDescending(s=>s.subscribers);
             }
             else
             {


### PR DESCRIPTION
fixes issue #647 where a subverse is listed twice if its name as well as
description contain the search query when "Also search in subverse
descriptions" is checked