### PR TITLE
Apply theme color to Chrome for Android

### DIFF
--- a/Voat/Voat.UI/Views/Shared/_Layout.cshtml
+++ b/Voat/Voat.UI/Views/Shared/_Layout.cshtml
@@ -109,6 +109,7 @@
 
     @* For Chrome for Android: *@
     <link rel="icon" sizes="192x192" href="~/Graphics/Icons/touch-icon-192x192.png">
+    <meta name="theme-color" content="#fff" />
     @* For iPhone 6 Plus with 3× display: *@
     <link rel="apple-touch-icon-precomposed" sizes="180x180" href="~/Graphics/Icons/apple-touch-icon-180x180-precomposed.png">
     @* For iPad with 2× display running iOS ≥ 7: *@


### PR DESCRIPTION
This change applies a color to the address bar and status bar on Chrome for Android (Chrome v39+ / Android 5.0+).

I'm not sure what color would look "the best", but having a color is a nice start. :)