### PR TITLE
 	Added view-height and scrolling to "My Subverses" menu

### DIFF
--- a/Voat/Voat.UI/Content/Voat.css
+++ b/Voat/Voat.UI/Content/Voat.css
@@ -1390,7 +1390,7 @@ pre, code {
             z-index: 99;
             overflow-x: hidden;
             overflow-y: scroll;
-            height: 80vh;
+            max-height: 80vh;
         }
 
             .whoaSubscriptionMenu li ul li {

--- a/Voat/Voat.UI/Content/Voat.css
+++ b/Voat/Voat.UI/Content/Voat.css
@@ -1391,6 +1391,7 @@ pre, code {
             overflow-x: hidden;
             overflow-y: scroll;
             max-height: 80vh;
+            height: 80vh;
         }
 
             .whoaSubscriptionMenu li ul li {


### PR DESCRIPTION
When subbed to many subverses the subverse menu was far off the screen and if you scrolled down too quickly you often scrolled off of it. This change adds 80% height to the menu and makes it scrollable.