### PR TITLE
Set reCAPTCHA language to English

### DIFF
--- a/Voat/Voat.UI/Views/Shared/_Captcha.cshtml
+++ b/Voat/Voat.UI/Views/Shared/_Captcha.cshtml
@@ -1,4 +1,4 @@
 ﻿@using System.Configuration
 
-<script src='https://www.google.com/recaptcha/api.js'></script>
+<script src='https://www.google.com/recaptcha/api.js?hl=en'></script>
 <div class="g-recaptcha" data-sitekey="@Settings.RecaptchaPublicKey"></div>


### PR DESCRIPTION
Since Voat’s UI is in English, I think it’s reasonable to set reCAPTCHA to English.

This will help avoid problems like [this](https://voat.co/v/voatdev/comments/310530), where a user is travelling to different countries or using a VPN and receives a captcha in a language they don’t understand.

This should be a temporary measure. If and when Voat is localised then the language value should be taken from some sort of account settings.