### PR TITLE
fixes #667

### DIFF
--- a/Voat/Voat.UI/Controllers/SubversesController.cs
+++ b/Voat/Voat.UI/Controllers/SubversesController.cs
@@ -1398,11 +1398,10 @@ namespace Voat.Controllers
         [ChildActionOnly]
         public ActionResult SubverseModeratorsList(string subverseName)
         {
-            // get 10 administration members for a subverse
+            // get administration members for a subverse
             var subverseAdministration =
                 _db.SubverseAdmins
                 .Where(n => n.SubverseName.Equals(subverseName, StringComparison.OrdinalIgnoreCase))
-                .Take(10)
                 .ToList()
                 .OrderBy(s => s.Username);
 


### PR DESCRIPTION
This removes the take(10) method from retrieving subverse admins, thus allowing all admins to be displayed