### PR TITLE
Get rid of the redundant percentage checking.

### DIFF
--- a/Voat/Voat.UI/Utils/User.cs
+++ b/Voat/Voat.UI/Utils/User.cs
@@ -825,15 +825,7 @@ namespace Voat.Utils
                 var commentUpvotes = db.Commentvotingtrackers.Count(a => a.UserName == userName && a.VoteStatus == 1);
                 var commentDownvotes = db.Commentvotingtrackers.Count(a => a.UserName == userName && a.VoteStatus == -1);
 
-                var totalCommentVotes = commentUpvotes + commentDownvotes;
-
-                // downvote ratio
-                var downvotePercentage = (double)commentDownvotes / totalCommentVotes * 100;
-
-                // upvote ratio
-                var upvotePercentage = (double)commentUpvotes / totalCommentVotes * 100;
-
-                return downvotePercentage > upvotePercentage;
+                return commentDownvotes > commentUpvotes;
             }
         }
 
@@ -846,15 +838,7 @@ namespace Voat.Utils
                 var submissionUpvotes = db.Votingtrackers.Count(a => a.UserName == userName && a.VoteStatus == 1);
                 var submissionDownvotes = db.Votingtrackers.Count(a => a.UserName == userName && a.VoteStatus == -1);
 
-                var totalSubmissionVotes = submissionUpvotes + submissionDownvotes;
-
-                // downvote ratio
-                var downvotePercentage = (double)submissionDownvotes / totalSubmissionVotes * 100;
-
-                // upvote ratio
-                var upvotePercentage = (double)submissionUpvotes / totalSubmissionVotes * 100;
-
-                return downvotePercentage > upvotePercentage;
+                return submissionDownvotes > submissionUpvotes;
             }
         }
 


### PR DESCRIPTION
You're not returning the percentages elsewhere, so you really don't need to convert them when you're really just checking if they downvote more than they upvote.

If you want to use different percentages later, multiply commentUpvotes by `(1 - x) / x` where `x` is the desired ratio of downvotes from 0.00 to 1.00. (e.g. if you consider anyone who votes more than 30% down a meanie, use `commentDownvotes > commentUpvotes * (0.7 / 0.3)` instead.