### PR TITLE
Adding "link + comment" button

### DIFF
--- a/Voat/Voat.UI/Views/Shared/Submissions/_SubmissionLink.cshtml
+++ b/Voat/Voat.UI/Views/Shared/Submissions/_SubmissionLink.cshtml
@@ -41,6 +41,7 @@
 
     DateTime submissionDate = Model.Date;
     string postAge = Submissions.CalcSubmissionAge(submissionDate);
+    string submissionUrl = Model.MessageContent;
 
     //type 2 = urls
     if (Model.Type == 2)
@@ -149,6 +150,7 @@
                     {
                         <a href="@commentsUrl" class="comments may-blank">discuss</a>
                     }
+                    <a href="javascript:void(0)" onclick="window.open('@submissionUrl', '_blank');window.open('@commentsUrl', '_blank');" class="comments may-blank">[l+c]</a>
 
                 </li>
                 @if (User.Identity.IsAuthenticated)

--- a/Voat/Voat.UI/Views/Shared/Submissions/_SubmissionLink.cshtml
+++ b/Voat/Voat.UI/Views/Shared/Submissions/_SubmissionLink.cshtml
@@ -10,7 +10,7 @@
     All portions of the code written by Voat are Copyright (c) 2014 Voat
     All Rights Reserved.*@
 
-@model Voat.Models.Message
+@model Voat.Data.Models.Message
 
 @{
     string ahrefTarget = "_self";
@@ -19,7 +19,7 @@
 
     if (User.Identity.IsAuthenticated)
     {
-        if (Voat.Utils.User.LinksInNewWindow(User.Identity.Name))
+        if (UserHelper.LinksInNewWindow(User.Identity.Name))
         {
             ahrefTarget = "_blank";
         }
@@ -63,7 +63,7 @@
                 else
                 {
                     <a class="thumbnail may-blank" href="@Model.MessageContent" target="@ahrefTarget">
-                        @if (MvcApplication.UseContentDeliveryNetwork)
+                        @if (Settings.UseContentDeliveryNetwork)
                         {
                             <img src="https://cdn.voat.co/thumbs/@Model.Thumbnail" alt="@Model.Linkdescription" />
                         }
@@ -87,7 +87,7 @@
                 else
                 {
                     <a class="thumbnail may-blank" href="@Model.MessageContent" target="@ahrefTarget">
-                        @if (MvcApplication.UseContentDeliveryNetwork)
+                        @if (Settings.UseContentDeliveryNetwork)
                         {
                             <img src="https://cdn.voat.co/thumbs/@Model.Thumbnail" alt="@Model.Linkdescription" />
                         }
@@ -151,7 +151,7 @@
                         <a href="@commentsUrl" class="comments may-blank">discuss</a>
                     }
                     <a href="javascript:void(0)" onclick="window.open('@submissionUrl', '_blank');window.open('@commentsUrl', '_blank');" class="comments may-blank">[l+c]</a>
-
+                    
                 </li>
                 @if (User.Identity.IsAuthenticated)
                 {
@@ -160,6 +160,12 @@
                         <li>
                             @Html.Partial("~/Views/Shared/Submissions/SubmissionFlatListButtons/_SFLButtonSave.cshtml", Model, new ViewDataDictionary { { "submissionId", Model.Id } })
                         </li>
+                        if (!string.IsNullOrEmpty(routeActiveSubverse) && routeActiveSubverse == "all")
+                        {
+                            <li>
+                                @Html.Partial("~/Views/Shared/Submissions/SubmissionFlatListButtons/_SFLButtonBlockSubverse.cshtml", Model, new ViewDataDictionary { { "subverseName", Model.Subverse } })
+                            </li>
+                        }pos
                     }
                 }
             </ul>


### PR DESCRIPTION
Implemented a useful RES feature that opens the link and the comments of a submission in two new tabs simultaneously.