### PR TITLE
Fix encoding for Suggest Title

### DIFF
--- a/Voat/Voat.Business/Utilities/UrlUtility.cs
+++ b/Voat/Voat.Business/Utilities/UrlUtility.cs
@@ -69,7 +69,7 @@ namespace Voat.Utilities
                     var titleNode = htmlDocument.DocumentNode.Descendants("title").SingleOrDefault();
                     if (titleNode != null)
                     {
-                        return titleNode.InnerText;
+                        return HttpUtility.HtmlDecode(titleNode.InnerText);
                     }
                 }
 

--- a/Voat/Voat.Tests/Utils/UrlUtilityTests.cs
+++ b/Voat/Voat.Tests/Utils/UrlUtilityTests.cs
@@ -61,5 +61,23 @@ namespace Voat.Tests.Utils
             bool result = UrlUtility.IsUriValid(testUri.ToString());
             Assert.AreEqual(true, result, "The input URI was invalid.");
         }
+
+        [TestMethod]
+        public void TestEscapedQuotesInTitle()
+        {
+            Uri testUri = new Uri("https://lwn.net/Articles/653411/");
+
+            string result = UrlUtility.GetTitleFromUri(testUri.ToString());
+            Assert.AreEqual("\"Big data\" features coming in PostgreSQL 9.5 [LWN.net]", result, "HTML in title not properly decoded");
+        }
+
+        [TestMethod]
+        public void TestTagInTitle()
+        {
+            Uri testUri = new Uri("http://stackoverflow.com/questions/1348683/will-the-b-and-i-tags-ever-become-deprecated");
+
+            string result = UrlUtility.GetTitleFromUri(testUri.ToString());
+            Assert.AreEqual("Will the <b> and <i> tags ever become deprecated?", result, "HTML in title not properly decoded");
+        }
     }
 }


### PR DESCRIPTION
When you go to https://voat.co/submit?linkpost=true, enter  https://lwn.net/Articles/653411/ as URL and let voat suggest a title, the title will begin with `&quot;Big data&quot;` instead of `"Bit data"`. This is because the UrlUtility doesn't decode HTML entities if the title is discovered via HTML (it does decode HTML entities if the title is discovered via OpenGraph).

The first commit is a one-line fix for this. I verified locally that this produces the desired result and doesn't open up XSS vulnerabilities.

The second commit adds a unit test for this. If you are internally replacing unit tests just say a word and I will remove the second commit again.