### PR TITLE
fixes #112

### DIFF
--- a/Voat/Voat.UI/Controllers/AjaxGatewayController.cs
+++ b/Voat/Voat.UI/Controllers/AjaxGatewayController.cs
@@ -94,7 +94,6 @@ namespace Voat.Controllers
 
             var subverseLinkFlairs = _db.Subverseflairsettings
                 .Where(n => n.Subversename == subversetoshow)
-                .Take(10)
                 .ToList()
                 .OrderBy(s => s.Id);
 

--- a/Voat/Voat.UI/Controllers/SubversesController.cs
+++ b/Voat/Voat.UI/Controllers/SubversesController.cs
@@ -1400,7 +1400,6 @@ namespace Voat.Controllers
             if (!UserHelper.IsUserSubverseModerator(User.Identity.Name, subversetoshow)) return RedirectToAction("Index", "Home");
             var subverseFlairsettings = _db.Subverseflairsettings
                 .Where(n => n.Subversename == subversetoshow)
-                .Take(20)
                 .OrderBy(s => s.Id)
                 .ToList();
 


### PR DESCRIPTION
This removes the `.Take(10)` method from retrieving subverse flair when trying to apply new flair, and removes the `.Take(20)` method from retrieving subverse flair on the edit page.  This should fix #112.