### PR TITLE
Fixed link to Voat mascot (fix #783)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/gmrwwisseq07emb4/branch/master?svg=true)](https://ci.appveyor.com/project/voat/voat/branch/master)
 [![license](http://img.shields.io/badge/license-GNU-blue.svg)](https://raw.githubusercontent.com/voat/voat/master/LICENSE)
 
-<img height="252" width="345" src="https://voat.co/Graphics/voat-goat.png" alt="Voat mascot" title="Voat" align="right" />
+<img height="252" width="345" src="Voat/Voat.UI/Graphics/voat-goat.png" alt="Voat mascot" title="Voat" align="right" />
 
 This is the code behind http://www.voat.co.
 


### PR DESCRIPTION
Made the link relative so that the image is displayed even if voat.co site is down. See issue #783 