### PR TITLE
Corrected a typo that affects ban reason limit

### DIFF
--- a/Voat/Voat.UI/Models/ViewModels/SubverseBanViewModel.cs
+++ b/Voat/Voat.UI/Models/ViewModels/SubverseBanViewModel.cs
@@ -25,7 +25,7 @@ namespace Voat.Models.ViewModels
         public string Subverse { get; set; }
 
         [Required(ErrorMessage = "Please enter a ban reason.")]
-        [StringLength(23, ErrorMessage = "Ban reason is limited to 50 characters.")]
+        [StringLength(50, ErrorMessage = "Ban reason is limited to 50 characters.")]
         public string Reason { get; set; }
     }
 }


### PR DESCRIPTION
Ban reason was limited to 23 characters, should now be 50.