### PR TITLE
Move the off-screen sidebar further left

### DIFF
--- a/Voat/Voat.UI/Content/Voat-Dark.css
+++ b/Voat/Voat.UI/Content/Voat-Dark.css
@@ -2934,7 +2934,7 @@ textarea.form-control {
     .side {
         position: absolute;
         top: -11px;
-        left: -310px;
+        left: -320px;
         transition: 500ms left;
         background-color: rgba(51, 51, 51, 1);
         margin: 0;

--- a/Voat/Voat.UI/Content/Voat-Dark.css
+++ b/Voat/Voat.UI/Content/Voat-Dark.css
@@ -2934,7 +2934,7 @@ textarea.form-control {
     .side {
         position: absolute;
         top: -11px;
-        left: -300px;
+        left: -310px;
         transition: 500ms left;
         background-color: rgba(51, 51, 51, 1);
         margin: 0;

--- a/Voat/Voat.UI/Content/Voat.css
+++ b/Voat/Voat.UI/Content/Voat.css
@@ -2888,7 +2888,7 @@ textarea.form-control {
     .side {
         position: absolute;
         top: -11px;
-        left: -310px;
+        left: -320px;
         transition: 500ms left;
         background-color: #FFFFFF;
         margin: 0;

--- a/Voat/Voat.UI/Content/Voat.css
+++ b/Voat/Voat.UI/Content/Voat.css
@@ -2888,7 +2888,7 @@ textarea.form-control {
     .side {
         position: absolute;
         top: -11px;
-        left: -300px;
+        left: -310px;
         transition: 500ms left;
         background-color: #FFFFFF;
         margin: 0;

--- a/Voat/Voat.UI/ddos.htm
+++ b/Voat/Voat.UI/ddos.htm
@@ -9467,7 +9467,7 @@ textarea.form-control {
     .side {
         position: absolute;
         top: -11px;
-        left: -310px;
+        left: -320px;
         transition: 500ms left;
         background-color: #FFFFFF;
         margin: 0;

--- a/Voat/Voat.UI/ddos.htm
+++ b/Voat/Voat.UI/ddos.htm
@@ -9467,7 +9467,7 @@ textarea.form-control {
     .side {
         position: absolute;
         top: -11px;
-        left: -300px;
+        left: -310px;
         transition: 500ms left;
         background-color: #FFFFFF;
         margin: 0;


### PR DESCRIPTION
When the browser is zoomed in, the off screen sidebar is slightly
visible, on the left edge of the window. Scrolling becomes a problem
if the mouse is placed over this visible portion. By moving the sidebar
further left, it stays off screen even if the browser is zoomed in.

Edit: Moved it even further left. Multiple commits is sloppy, but I used the Github online file editor because lazy.