### PR TITLE
increased dailyGlobalPostingQuota and decreased dailyPostingQuotaPerSub

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -28,8 +28,8 @@
     <add key="maximumOwnedSubs" value="10" />
     <add key="maximumOwnedSets" value="20" />
     <add key="forceHTTPS" value="true" />
-    <add key="dailyPostingQuotaPerSub" value="10" />
-	<add key="dailyGlobalPostingQuota" value="5" />
+    <add key="dailyPostingQuotaPerSub" value="5" />
+	<add key="dailyGlobalPostingQuota" value="15" />
     <add key="dailyVotingQuota" value="100" />
     <add key="hourlyGlobalPostingQuota" value="3" />
     <add key="hourlyPostingQuotaPerSub" value="3" />


### PR DESCRIPTION
former was higher than latter causing it to be redundant and many users complained about only being able to post 5 times a day.