### PR TITLE
Fixing Typo in Contributing File

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Voat
 
-We use [git-flow branching model](http://nvie.com/posts/a-successful-git-branching-model/"). 
+We use [git-flow branching model](http://nvie.com/posts/a-successful-git-branching-model/). 
 
 ## Git-flow concept summary
 


### PR DESCRIPTION
the link to the git-flow branching model had an extra quotation mark, making the link go to a 404
