### PR TITLE
allow Unicode characters in submission titles, per #411 (also fix javascript: exploit)

### DIFF
--- a/Voat/Voat.Business/Data/DataGateway.cs
+++ b/Voat/Voat.Business/Data/DataGateway.cs
@@ -724,8 +724,8 @@ namespace Voat.Data {
             if (String.IsNullOrEmpty(submission.Title)) {
                 throw new VoatValidationException("Submission must have a title.");
             }
-            if (Submissions.ContainsUnicode(submission.Title)) {
-                throw new VoatValidationException("Submission title can not contain Unicode characters.");
+            if (!submission.Title.Equals(Submissions.StripIllegalUnicode(submission.Title))) {
+                throw new VoatValidationException("Submission title can not contain illegal Unicode characters.");
             }
             if (!SubverseExists(subverse)) {
                 throw new VoatValidationException(String.Format("Subverse '{0}' does not exist.", subverse));
@@ -797,8 +797,8 @@ namespace Voat.Data {
             //allow edit of title if in 10 minute window
             if (CurrentDate.Subtract(m.CreationDate).TotalMinutes <= 10.0f) {
 
-                if (!String.IsNullOrEmpty(submission.Title) && Utilities.Submissions.ContainsUnicode(submission.Title)) {
-                    throw new VoatValidationException("Submission title can not contain Unicode characters.");
+                if (!String.IsNullOrEmpty(submission.Title) && !submission.Title.Equals(Submissions.StripIllegalUnicode(submission.Title))) {
+                    throw new VoatValidationException("Submission title can not contain illegal Unicode characters.");
                 }
 
                 if (m.Type == 1) {

--- a/Voat/Voat.Business/Utilities/Submissions.cs
+++ b/Voat/Voat.Business/Utilities/Submissions.cs
@@ -94,7 +94,7 @@ namespace Voat.Utilities
         // remove illegal unicode characters from a string
         public static string StripIllegalUnicode(string stringToClean)
         {
-            return Regex.Replace(stringToClean, @"[^\p{L}\p{N}\p{M}\p{P}\p{Zs}\u0020-\u007F]", string.Empty).Normalize(NormalizationForm.FormKC);
+            return Regex.Replace(stringToClean, @"[^\p{L}\p{N}\p{M}\p{P}\u0020-\u007F\u200B\u200C\u200D\u200E\u200F\u202A\u202B\u202C\u202D\u202E]", string.Empty).Normalize(NormalizationForm.FormKC);
         }
 
         // add new submission

--- a/Voat/Voat.Business/Utilities/Submissions.cs
+++ b/Voat/Voat.Business/Utilities/Submissions.cs
@@ -94,7 +94,7 @@ namespace Voat.Utilities
         // remove illegal unicode characters from a string
         public static string StripIllegalUnicode(string stringToClean)
         {
-            return Regex.Replace(stringToClean, @"[^\p{L}\p{N}\p{M}\p{P}\u0020-\u007F\u200B\u200C\u200D\u200E\u200F\u202A\u202B\u202C\u202D\u202E]", string.Empty).Normalize(NormalizationForm.FormKC);
+            return Regex.Replace(stringToClean, @"[^\p{L}\p{N}\p{M}\p{P}\u0020-\u007F\u200B-\u200F\u202A-\u202E]", string.Empty).Normalize(NormalizationForm.FormKC);
         }
 
         // add new submission

--- a/Voat/Voat.Business/Utilities/Submissions.cs
+++ b/Voat/Voat.Business/Utilities/Submissions.cs
@@ -14,6 +14,7 @@ All Rights Reserved.
 
 using System;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
@@ -90,17 +91,10 @@ namespace Voat.Utilities
             return duration.TotalHours;
         }
 
-        // check if a string contains unicode characters
-        public static bool ContainsUnicode(string stringToTest)
+        // remove illegal unicode characters from a string
+        public static string StripIllegalUnicode(string stringToClean)
         {
-            const int maxAnsiCode = 255;
-            return stringToTest.Any(c => c > maxAnsiCode);
-        }
-
-        // string unicode characters from a string
-        public static string StripUnicode(string stringToClean)
-        {
-            return Regex.Replace(stringToClean, @"[^\u0000-\u007F]", string.Empty);
+            return Regex.Replace(stringToClean, @"[^\p{L}\p{N}\p{M}\p{P}\p{Zs}\u0020-\u007F]", string.Empty).Normalize(NormalizationForm.FormKC);
         }
 
         // add new submission
@@ -112,10 +106,7 @@ namespace Voat.Utilities
                 if (submissionModel.Type == 2)
                 {
                     // strip unicode if title contains unicode
-                    if (ContainsUnicode(submissionModel.LinkDescription))
-                    {
-                        submissionModel.LinkDescription = StripUnicode(submissionModel.LinkDescription);
-                    }
+                    submissionModel.LinkDescription = StripIllegalUnicode(submissionModel.LinkDescription);
 
                     // reject if title is whitespace or < than 5 characters
                     if (submissionModel.LinkDescription.Length < 5 || String.IsNullOrWhiteSpace(submissionModel.LinkDescription))
@@ -169,10 +160,7 @@ namespace Voat.Utilities
                 // MESSAGE TYPE SUBMISSION
                 {
                     // strip unicode if submission contains unicode
-                    if (ContainsUnicode(submissionModel.Title))
-                    {
-                        submissionModel.Title = StripUnicode(submissionModel.Title);
-                    }
+                    submissionModel.Title = StripIllegalUnicode(submissionModel.Title);
 
                     // reject if title is whitespace or less than 5 characters
                     if (submissionModel.Title.Length < 5 || String.IsNullOrWhiteSpace(submissionModel.Title))

--- a/Voat/Voat.Tests/UnitTests.cs
+++ b/Voat/Voat.Tests/UnitTests.cs
@@ -135,7 +135,7 @@ namespace UnitTests
             string result = Submissions.StripIllegalUnicode(testString1);
             Assert.IsTrue(result.Equals(testStringAllowedUnicode));
             
-            const string testString2 = "\x0008NSA holds info over US citizens \x200Flike\n loaded gun, but \x2029says ‘trust me’ – Snowden";
+            const string testString2 = "\x0008NSA holds info over US citizens \x200Alike\n loaded gun, but \x2029says ‘trust me’ – Snowden";
             const string testStringNotAllowedUnicode = "NSA holds info over US citizens like loaded gun, but says ‘trust me’ – Snowden";
 
             result = Submissions.StripIllegalUnicode(testString2);

--- a/Voat/Voat.Tests/UnitTests.cs
+++ b/Voat/Voat.Tests/UnitTests.cs
@@ -127,26 +127,19 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void TestUnicodeDetection()
-        {
-            const string testString = "🆆🅰🆂 🅶🅴🆃🆃🅸🅽🅶 🅲🅰🆄🅶🅷🆃 🅿🅰🆁🆃 🅾🅵 🆈🅾🆄🆁 🅿🅻🅰🅽🅴";
-            const string testStringWithoutUnicode = "was getting caught part of your plane";
-
-            bool result = Submissions.ContainsUnicode(testString);
-            Assert.IsTrue(result, "Unicode was not detected.");
-
-            bool resultWithoutUnicode = Submissions.ContainsUnicode(testStringWithoutUnicode);
-            Assert.IsFalse(resultWithoutUnicode, "Unicode was not detected.");
-        }
-
-        [TestMethod]
         public void TestUnicodeStripping()
         {
-            const string testString = "NSA holds info over US citizens like loaded gun, but says ‘trust me’ – Snowden";
-            const string testStringWithoutUnicode = "NSA holds info over US citizens like loaded gun, but says trust me  Snowden";
+            const string testString1 = "NSA holds info over US citizens like loaded gun, but says ‘trust me’ – Snowden";
+            const string testStringAllowedUnicode = "NSA holds info over US citizens like loaded gun, but says ‘trust me’ – Snowden";
 
-            string result = Submissions.StripUnicode(testString);
-            Assert.IsTrue(result.Equals(testStringWithoutUnicode));
+            string result = Submissions.StripIllegalUnicode(testString1);
+            Assert.IsTrue(result.Equals(testStringAllowedUnicode));
+            
+            const string testString2 = "\x0008NSA holds info over US citizens \x200Flike\n loaded gun, but \x2029says ‘trust me’ – Snowden";
+            const string testStringNotAllowedUnicode = "NSA holds info over US citizens like loaded gun, but says ‘trust me’ – Snowden";
+
+            result = Submissions.StripIllegalUnicode(testString2);
+            Assert.IsTrue(result.Equals(testStringNotAllowedUnicode));
         }
 
     }

--- a/Voat/Voat.UI/Controllers/SubmissionsController.cs
+++ b/Voat/Voat.UI/Controllers/SubmissionsController.cs
@@ -191,7 +191,8 @@ namespace Voat.Controllers
 
             if (existingSubmission.IsDeleted) return Json("This submission has been deleted.", JsonRequestBehavior.AllowGet);
             if (existingSubmission.UserName.Trim() != User.Identity.Name) return Json("Unauthorized edit.", JsonRequestBehavior.AllowGet);
-
+            if (existingSubmission.Type == 2 && !UrlUtility.IsUriValid(model.SubmissionContent)) return Json("Invalid URI.", JsonRequestBehavior.AllowGet);
+            
             existingSubmission.Content = model.SubmissionContent;
             existingSubmission.LastEditDate = DateTime.Now;
 

--- a/Voat/Voat.UI/MessagingHub.cs
+++ b/Voat/Voat.UI/MessagingHub.cs
@@ -54,8 +54,8 @@ namespace Voat
                     return;
                 }
 
-                // discard message if it contains unicode
-                if (Submissions.ContainsUnicode(message))
+                // discard message if it contains illegal unicode
+                if (!message.Equals(Submissions.StripIllegalUnicode(message)))
                 {
                     return;
                 }


### PR DESCRIPTION
This uses Unicode character classes/categories and NFKC normalization to validate characters. Also updated unit tests accordingly.
