### PR TITLE
bugfix: update comment tree cache on vote

### DIFF
--- a/Voat/Voat.Business/Domain/Command/VoteCommands.cs
+++ b/Voat/Voat.Business/Domain/Command/VoteCommands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Voat.Caching;
 using Voat.Data;
 using Voat.Models;
 using Voat.Utilities;
@@ -8,11 +9,14 @@ namespace Voat.Domain.Command
 {
     public class CommentVoteCommand : VoteCommand
     {
-        public CommentVoteCommand(int commentID, int voteValue, string addressHash, bool revokeOnRevote = true)
+        private readonly int? _submissionID;
+
+        public CommentVoteCommand(int commentID, int? submissionID, int voteValue, string addressHash, bool revokeOnRevote = true)
             : base(voteValue, addressHash)
         {
             CommentID = commentID;
             RevokeOnRevote = revokeOnRevote;
+            _submissionID = submissionID;
         }
 
         public int CommentID { get; private set; }
@@ -34,9 +38,9 @@ namespace Voat.Domain.Command
 
         protected override void UpdateCache(VoteResponse result)
         {
-            if (result.Success)
+            if (result.Success && _submissionID.HasValue)
             {
-                //update cache somehow
+                CacheHandler.Instance.Remove(CachingKey.CommentTree(_submissionID.Value));
             }
         }
     }

--- a/Voat/Voat.Tests/CommandTests/VoteCommandTests.cs
+++ b/Voat/Voat.Tests/CommandTests/VoteCommandTests.cs
@@ -45,7 +45,7 @@ namespace Voat.Tests.CommandTests
             EventNotification.Instance.OnVoteReceived += (s, e) => {
               voteEventReceived = e.TargetUserName == "unit" && e.SendingUserName == "User500CCP" && e.ChangeValue == -1 && e.ReferenceType == Domain.Models.ContentType.Comment && e.ReferenceID == 1;
             };
-            var cmd = new CommentVoteCommand(1, -1, IpHash.CreateHash("127.0.0.1"));
+            var cmd = new CommentVoteCommand(1, default(int?), -1, IpHash.CreateHash("127.0.0.1"));
 
             var c = cmd.Execute().Result;
             Assert.IsTrue(c.Success);
@@ -94,7 +94,7 @@ namespace Voat.Tests.CommandTests
         {
             TestHelper.SetPrincipal("User0CCP");
 
-            var cmd = new CommentVoteCommand(5, -1, IpHash.CreateHash("127.0.0.1")); //SubmissionID: 3 is in MinCCP sub
+            var cmd = new CommentVoteCommand(5, default(int?), -1, IpHash.CreateHash("127.0.0.1")); //SubmissionID: 3 is in MinCCP sub
 
             var c = cmd.Execute().Result;
             Assert.IsFalse(c.Success);
@@ -109,7 +109,7 @@ namespace Voat.Tests.CommandTests
         public void InvalidVoteValue_Comment_Low()
         {
             TestHelper.SetPrincipal("unit");
-            var cmd = new CommentVoteCommand(1, -2, IpHash.CreateHash("127.0.0.1"));
+            var cmd = new CommentVoteCommand(1, default(int?), -2, IpHash.CreateHash("127.0.0.1"));
             var c = cmd.Execute().Result;
         }
 
@@ -120,7 +120,7 @@ namespace Voat.Tests.CommandTests
         public void UpvoteComment()
         {
             TestHelper.SetPrincipal("User50CCP");
-            var cmd = new CommentVoteCommand(1, 1, IpHash.CreateHash("127.0.0.2"));
+            var cmd = new CommentVoteCommand(1, default(int?), 1, IpHash.CreateHash("127.0.0.2"));
 
             var c = cmd.Execute().Result;
             Assert.IsNotNull(c, "Response is null");
@@ -248,7 +248,7 @@ namespace Voat.Tests.CommandTests
         {
             TestHelper.SetPrincipal("unit");
 
-            var cmd = new CommentVoteCommand(1, -2, IpHash.CreateHash("127.0.0.1"));
+            var cmd = new CommentVoteCommand(1, default(int?), -2, IpHash.CreateHash("127.0.0.1"));
 
             var c = cmd.Execute().Result;
         }

--- a/Voat/Voat.Tests/QueryTests/QueryCommentTests.cs
+++ b/Voat/Voat.Tests/QueryTests/QueryCommentTests.cs
@@ -26,7 +26,7 @@ namespace Voat.Tests.QueryTests
             Assert.IsNotNull(comment, "Comment is null 1");
             Assert.AreEqual(0, comment.Vote, "vote value not set for logged in user 1");
 
-            var cmd = new CommentVoteCommand(1, 1, IpHash.CreateHash(Guid.NewGuid().ToString()));
+            var cmd = new CommentVoteCommand(1, default(int?), 1, IpHash.CreateHash(Guid.NewGuid().ToString()));
             var result = cmd.Execute().Result;
             Assert.IsNotNull(result, "Result is null");
             Assert.AreEqual(Status.Success, result.Status);

--- a/Voat/Voat.UI/Controllers/CommentController.cs
+++ b/Voat/Voat.UI/Controllers/CommentController.cs
@@ -16,12 +16,14 @@ All Rights Reserved.
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using Voat.Caching;
+using Voat.Common;
 using Voat.Configuration;
 using Voat.Data;
 using Voat.Data.Models;
@@ -47,7 +49,13 @@ namespace Voat.Controllers
         [VoatValidateAntiForgeryToken]
         public async Task<JsonResult> VoteComment(int commentId, int typeOfVote)
         {
-            var cmd = new CommentVoteCommand(commentId, typeOfVote, IpHash.CreateHash(UserHelper.UserIpAddress(this.Request)));
+            var comment = await _db.Comments.FirstOrDefaultAsync();
+            if (comment == null)
+            {
+                throw new VoatNotFoundException("Can not find comment with id {0}", commentId.ToString());
+            }
+
+            var cmd = new CommentVoteCommand(commentId, comment.SubmissionID, typeOfVote, IpHash.CreateHash(UserHelper.UserIpAddress(this.Request)));
             var result = await cmd.Execute();
             return Json(result);
         }

--- a/Voat/Voat.UI/Controllers/CommentController.cs
+++ b/Voat/Voat.UI/Controllers/CommentController.cs
@@ -13,29 +13,23 @@ All Rights Reserved.
 */
 
 //using Microsoft.AspNet.SignalR;
-using Newtonsoft.Json;
+
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using Voat.Caching;
 using Voat.Common;
-using Voat.Configuration;
-using Voat.Data;
 using Voat.Data.Models;
-using Voat.Domain;
 using Voat.Domain.Command;
 using Voat.Domain.Models;
 using Voat.Domain.Query;
-using Voat.Models;
 using Voat.Models.ViewModels;
 using Voat.UI.Utilities;
 using Voat.Utilities;
-using Voat.Utilities.Components;
 
 namespace Voat.Controllers
 {
@@ -52,7 +46,7 @@ namespace Voat.Controllers
             var comment = await _db.Comments.FirstOrDefaultAsync();
             if (comment == null)
             {
-                throw new VoatNotFoundException("Can not find comment with id {0}", commentId.ToString());
+                throw new VoatNotFoundException("Comment with ID {0} not found.", commentId.ToString());
             }
 
             var cmd = new CommentVoteCommand(commentId, comment.SubmissionID, typeOfVote, IpHash.CreateHash(UserHelper.UserIpAddress(this.Request)));


### PR DESCRIPTION
See #https://github.com/voat/voat/issues/881 for background.

When voting, the cache isn't updated for the comment tree. The state in the database is consistent when upvoting/downvoting, but you'll end up in a weird state where you can vote for things and they appear to have one more vote than they really do.

Fixing this bug is as simple as removing the old data from the cache when processing a vote command.