### PR TITLE
bugfix: preserve "all" time span for paging

### DIFF
--- a/Voat/Voat.UI/Controllers/SubversesController.cs
+++ b/Voat/Voat.UI/Controllers/SubversesController.cs
@@ -1273,8 +1273,8 @@ namespace Voat.Controllers
 
             //Null out defaults
             viewProperties.Sort = options.Sort == Domain.Models.SortAlgorithm.Rank ? (Domain.Models.SortAlgorithm?)null : options.Sort;
-            viewProperties.Span = options.Span == Domain.Models.SortSpan.All ? (Domain.Models.SortSpan?)null : options.Span;
-           
+            viewProperties.Span = options.Span;
+
             try
             {
                 PaginatedList<Submission> pageList = null;


### PR DESCRIPTION
See #875 for background

By nulling out the value of Span, the view logic can't append the string representation of the "All" span to the url for "next" and "previous" links. The usages of this particular "Span" property are limited to SubverseIndex.cshtml from what I could tell.